### PR TITLE
Require time to support `to_time` coercions

### DIFF
--- a/lib/transproc/coercions.rb
+++ b/lib/transproc/coercions.rb
@@ -1,4 +1,5 @@
 require 'date'
+require 'time'
 require 'bigdecimal'
 require 'bigdecimal/util'
 


### PR DESCRIPTION
Before this change running specs _without_ `bundle exec` failed:

    $ rake
    -I/home/peter/.rvm/gems/ruby-2.1.5@pg/gems/rspec-support-3.1.2/lib:/home/peter/.rvm/gems/ruby-2.1.5@pg/gems/rspec-core-3.1.7/lib/home/peter/.rvm/gems/ruby-2.1.5@pg/gems/rspec-core-3.1.7/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
    ..............F..............................

    Failures:

      1) Transproc / Coercions to_time turns string into a time object
         Failure/Error: expect(Transproc(:to_time)['2012-01-23
    11:07:07']).to eql(time)
         NoMethodError:
           undefined method `parse' for Time:Class
         # ./lib/transproc/coercions.rb:38:in `block in <module:Transproc>'
         # ./lib/transproc/function.rb:11:in `[]'
         # ./lib/transproc/function.rb:11:in `call'
         # ./spec/integration/coercions_spec.rb:50:in `block (3 levels) in
         # <top (required)>'

    Finished in 0.01416 seconds (files took 0.18873 seconds to load)
    45 examples, 1 failure

    Failed examples:

    rspec ./spec/integration/coercions_spec.rb:48 # Transproc / Coercions
    to_time turns string into a time object

`time` is not required by default in which `Time.parse` is defined.

    $ irb
    >> Time.parse
    NoMethodError: undefined method `parse' for Time:Class
      from (irb):1
      from /home/peter/.rvm/rubies/ruby-2.1.5/bin/irb:11:in `<main>'
    >> require 'time'
    => true
    >> Time.parse
    ArgumentError: wrong number of arguments (0 for 1..2)
      from /home/peter/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/time.rb:323:in
    `parse'
      from (irb):3
      from /home/peter/.rvm/rubies/ruby-2.1.5/bin/irb:11:in `<main>'