### PR TITLE
Speedup transproc `map_array!`

### DIFF
--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -4,7 +4,8 @@ module Transproc
   end
 
   register(:map_array!) do |array, *fns|
-    array.map! { |value| fns.reduce(:+)[value] }
+    fn = fns.size == 1 ? fns[0] : fns.reduce(:+)
+    array.map! { |value| fn[value] }
   end
 
   register(:wrap) do |array, key, keys|


### PR DESCRIPTION
Compose applied function only once per call not per each iteration.

### Benchmark

```ruby
require 'transproc/all'
require 'benchmark/ips'

f = Transproc(:map_array!, Transproc(:to_string))
f_old = Transproc(:map_array_old!, Transproc(:to_string))

4.times do |i|
  size = 10 ** i
  input = [:test] * size

  Benchmark.ips do |x|
    x.report "map_array! #{size}" do
      f[input]
    end

    x.report "map_array! old #{size}" do
      f_old[input]
    end

    x.compare!
  end
end
```

## Results

```
$ ruby -Ilib foo.rb 
Calculating -------------------------------------
        map_array! 1    21.065k i/100ms
    map_array! old 1    21.397k i/100ms
-------------------------------------------------
        map_array! 1    667.279k (± 8.8%) i/s -      3.307M
    map_array! old 1    530.256k (± 4.1%) i/s -      2.653M

Comparison:
        map_array! 1:   667278.8 i/s
    map_array! old 1:   530255.7 i/s - 1.26x slower

Calculating -------------------------------------
       map_array! 10     9.999k i/100ms
   map_array! old 10     7.473k i/100ms
-------------------------------------------------
       map_array! 10    162.456k (± 4.1%) i/s -    819.918k
   map_array! old 10     95.526k (± 4.2%) i/s -    478.272k

Comparison:
       map_array! 10:   162456.0 i/s
   map_array! old 10:    95525.7 i/s - 1.70x slower

Calculating -------------------------------------
      map_array! 100     1.817k i/100ms
  map_array! old 100   993.000  i/100ms
-------------------------------------------------
      map_array! 100     18.020k (±16.8%) i/s -     87.216k
  map_array! old 100      9.834k (±15.5%) i/s -     47.664k

Comparison:
      map_array! 100:    18019.8 i/s
  map_array! old 100:     9834.2 i/s - 1.83x slower

Calculating -------------------------------------
     map_array! 1000   191.000  i/100ms
 map_array! old 1000    92.000  i/100ms
-------------------------------------------------
     map_array! 1000      1.953k (± 2.4%) i/s -      9.932k
 map_array! old 1000      1.024k (± 5.9%) i/s -      5.152k

Comparison:
     map_array! 1000:     1953.4 i/s
 map_array! old 1000:     1024.0 i/s - 1.91x slower
```

The longer the input array the bigger the performance improvement.