### PR TITLE
Speedup transproc `group`

### DIFF
--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -13,17 +13,14 @@ module Transproc
   end
 
   register(:group) do |array, key, keys|
-    names = nil
-
-    array
-      .group_by { |hash|
-        names ||= hash.keys - keys
-        Hash[names.zip(hash.values_at(*names))]
-      }
-      .map { |root, children|
-        children.map! { |child| Hash[keys.zip(child.values_at(*keys))] }
-        children.select! { |child| child.values.any? }
-        root.merge(key => children)
-      }
+    grouped = Hash.new { |hash, key| hash[key] = [] }
+    array.each do |hash|
+      child = {}
+      keys.each { |k| child[k] = hash.delete(k) }
+      grouped[hash] << child
+    end
+    grouped.map do |root, children|
+      root.merge(key => children)
+    end
   end
 end

--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -15,6 +15,7 @@ module Transproc
   register(:group) do |array, key, keys|
     grouped = Hash.new { |hash, key| hash[key] = [] }
     array.each do |hash|
+      hash = hash.dup
       child = {}
       keys.each { |k| child[k] = hash.delete(k) }
       grouped[hash] << child


### PR DESCRIPTION
Note, that grouping is now destructive (see `input.dup` in benchmark).
It this ok?

### Benchmark

```ruby
require 'transproc/all'
require 'benchmark/ips'

key = :tasks
keys = [:tasks_id, :title]
input_row = { :id=>nil, :name=>"name 1", :email=>"email_1@domain.com", :age=>10, :tasks_id=>6, :title=>"Task 2" }

f = Transproc(:group, key, keys)
f_old = Transproc(:group_old, key, keys)

4.times do |i|
  size = 10 ** i
  input = size.times.map { |i| input_row.merge(:id => i % 5) }

  Benchmark.ips do |x|
    x.report "group #{size}" do
      f[input.dup]
    end

    x.report "group old #{size}" do
      f_old[input.dup]
    end

    x.compare!
  end
end
```

### Result

```
$ ruby -Ilib group.rb 
Calculating -------------------------------------
             group 1     3.996k i/100ms
         group old 1     3.661k i/100ms
-------------------------------------------------
             group 1     47.155k (± 0.7%) i/s -    235.764k
         group old 1     42.232k (± 0.7%) i/s -    212.338k

Comparison:
             group 1:    47155.5 i/s
         group old 1:    42231.5 i/s - 1.12x slower

Calculating -------------------------------------
            group 10   783.000  i/100ms
        group old 10   557.000  i/100ms
-------------------------------------------------
            group 10      8.111k (± 0.6%) i/s -     40.716k
        group old 10      5.696k (± 0.9%) i/s -     28.964k

Comparison:
            group 10:     8111.4 i/s
        group old 10:     5695.8 i/s - 1.42x slower

Calculating -------------------------------------
           group 100   119.000  i/100ms
       group old 100    73.000  i/100ms
-------------------------------------------------
           group 100      1.215k (± 0.7%) i/s -      6.188k
       group old 100    737.500  (± 0.9%) i/s -      3.723k

Comparison:
           group 100:     1214.7 i/s
       group old 100:      737.5 i/s - 1.65x slower

Calculating -------------------------------------
          group 1000    12.000  i/100ms
      group old 1000     7.000  i/100ms
-------------------------------------------------
          group 1000    125.834  (± 0.8%) i/s -    636.000 
      group old 1000     75.566  (± 1.3%) i/s -    378.000 

Comparison:
          group 1000:      125.8 i/s
      group old 1000:       75.6 i/s - 1.67x slower
```