### PR TITLE
Add transform_keys(!) and re-use in symbolize_keys(!)/stringify_keys(!)

### DIFF
--- a/lib/transproc/coercions.rb
+++ b/lib/transproc/coercions.rb
@@ -15,6 +15,10 @@ module Transproc
     value.to_s
   end
 
+  register(:to_symbol) do |value|
+    value.to_sym
+  end
+
   register(:to_integer) do |value|
     value.to_i
   end

--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -1,11 +1,27 @@
 module Transproc
+  register(:transform_keys) do |hash, fn|
+    Transproc(:transform_keys!, fn)[Hash[hash]]
+  end
+
+  register(:transform_keys!) do |hash, fn|
+    hash.keys.each { |key| hash[fn[key]] = hash.delete(key) }
+    hash
+  end
+
   register(:symbolize_keys) do |hash|
     Transproc(:symbolize_keys!)[Hash[hash]]
   end
 
   register(:symbolize_keys!) do |hash|
-    hash.keys.each { |key| hash[key.to_sym] = hash.delete(key) }
-    hash
+    Transproc(:transform_keys!, Transproc(:to_symbol))[hash]
+  end
+
+  register(:stringify_keys) do |hash|
+    Transproc(:stringify_keys!)[Hash[hash]]
+  end
+
+  register(:stringify_keys!) do |hash|
+    Transproc(:transform_keys!, Transproc(:to_string))[hash]
   end
 
   register(:map_hash) do |hash, mapping|

--- a/spec/integration/coercions_spec.rb
+++ b/spec/integration/coercions_spec.rb
@@ -7,6 +7,12 @@ describe 'Transproc / Coercions' do
     end
   end
 
+  describe 'to_symbol' do
+    it 'turns string into a symbol' do
+      expect(t(:to_symbol)['test']).to eql(:test)
+    end
+  end
+
   describe 'to_integer' do
     it 'turns string into an integer' do
       expect(t(:to_integer)['1']).to eql(1)

--- a/spec/integration/hash_spec.rb
+++ b/spec/integration/hash_spec.rb
@@ -1,6 +1,30 @@
 require 'spec_helper'
 
 describe 'Hash mapping with Transproc' do
+  describe 'transform_keys' do
+    it 'returns a new hash with transformation proc applied to keys' do
+      transform_keys = t(:transform_keys, ->(key) { key.strip })
+
+      input = { ' foo ' => 'bar' }
+      output = { 'foo' => 'bar' }
+
+      expect(transform_keys[input]).to eql(output)
+      expect(input).to eql(' foo ' => 'bar')
+    end
+  end
+
+  describe 'transform_keys!' do
+    it 'returns updated hash with transformation proc applied to keys' do
+      transform_keys = t(:transform_keys!, ->(key) { key.strip })
+
+      input = { ' foo ' => 'bar' }
+      output = { 'foo' => 'bar' }
+
+      expect(transform_keys[input]).to eql(output)
+      expect(input).to eql('foo' => 'bar')
+    end
+  end
+
   describe 'symbolize_keys' do
     it 'returns a new hash with symbolized keys' do
       symbolize_keys = t(:symbolize_keys)
@@ -21,6 +45,80 @@ describe 'Hash mapping with Transproc' do
       output = { foo: 'bar' }
 
       symbolize_keys[input]
+
+      expect(input).to eql(output)
+    end
+  end
+
+  describe 'stringify_keys' do
+    it 'returns a new hash with stringified keys' do
+      stringify_keys = t(:stringify_keys)
+
+      input = { foo: 'bar' }
+      output = { 'foo' => 'bar' }
+
+      expect(stringify_keys[input]).to eql(output)
+      expect(input).to eql(foo: 'bar')
+    end
+  end
+
+  describe 'stringify_keys!' do
+    it 'returns a new hash with stringified keys' do
+      stringify_keys = t(:stringify_keys!)
+
+      input = { foo: 'bar' }
+      output = { 'foo' => 'bar' }
+
+      expect(stringify_keys[input]).to eql(output)
+      expect(input).to eql('foo' => 'bar')
+    end
+  end
+
+  describe 'map_hash' do
+    it 'returns a new hash with applied functions' do
+      map = t(:map_hash, 'foo' => :foo)
+
+      input = { 'foo' => 'bar', :bar => 'baz' }
+      output = { foo: 'bar', bar: 'baz' }
+
+      expect(map[input]).to eql(output)
+      expect(input).to eql('foo' => 'bar', :bar => 'baz')
+    end
+  end
+
+  describe 'map_hash!' do
+    it 'returns updated hash with applied functions' do
+      map = t(:map_hash!, 'foo' => :foo)
+
+      input = { 'foo' => 'bar', :bar => 'baz' }
+      output = { foo: 'bar', bar: 'baz' }
+
+      map[input]
+
+      expect(input).to eql(output)
+    end
+  end
+
+  describe 'map_key' do
+    it 'applies function to value under specified key' do
+      transformation = t(:map_key, :user, t(:symbolize_keys))
+
+      input = { user: { 'name' => 'Jane' } }
+      output = { user: { name: 'Jane' } }
+
+      expect(transformation[input]).to eql(output)
+      expect(input).to eql(user: { 'name' => 'Jane' })
+    end
+  end
+
+  describe 'map_key!' do
+    it 'applies function to value under specified key' do
+      transformation = t(:map_key!, :user, t(:symbolize_keys))
+
+      input = { user: { 'name' => 'Jane' } }
+      output = { user: { name: 'Jane' } }
+
+      transformation[input]
 
       expect(input).to eql(output)
     end
@@ -98,56 +196,6 @@ describe 'Hash mapping with Transproc' do
       expect(unwrap[input]).to eql({'foo' => 'bar',
                                     'one' => nil,
                                     'two' => false})
-    end
-  end
-
-  describe 'map_hash' do
-    it 'returns a new hash with applied functions' do
-      map = t(:map_hash, 'foo' => :foo)
-
-      input = { 'foo' => 'bar', :bar => 'baz' }
-      output = { foo: 'bar', bar: 'baz' }
-
-      expect(map[input]).to eql(output)
-      expect(input).to eql('foo' => 'bar', :bar => 'baz')
-    end
-  end
-
-  describe 'map_hash!' do
-    it 'returns updated hash with applied functions' do
-      map = t(:map_hash!, 'foo' => :foo)
-
-      input = { 'foo' => 'bar', :bar => 'baz' }
-      output = { foo: 'bar', bar: 'baz' }
-
-      map[input]
-
-      expect(input).to eql(output)
-    end
-  end
-
-  describe 'map_key' do
-    it 'applies function to value under specified key' do
-      transformation = t(:map_key, :user, t(:symbolize_keys))
-
-      input = { user: { 'name' => 'Jane' } }
-      output = { user: { name: 'Jane' } }
-
-      expect(transformation[input]).to eql(output)
-      expect(input).to eql(user: { 'name' => 'Jane' })
-    end
-  end
-
-  describe 'map_key!' do
-    it 'applies function to value under specified key' do
-      transformation = t(:map_key!, :user, t(:symbolize_keys))
-
-      input = { user: { 'name' => 'Jane' } }
-      output = { user: { name: 'Jane' } }
-
-      transformation[input]
-
-      expect(input).to eql(output)
     end
   end
 


### PR DESCRIPTION
Allows easier definition of custom key transformations, such as:

```ruby
require 'transproc/all'
require 'active_support/inflector'

fn = Transproc(:hash_recursion, Transproc(:transform_keys, ->(key) { ActiveSupport::Inflector.camelize(key, false).to_sym }))

fn['user' => {'title' => 'Mr', 'first_name' => 'John', 'last_name' => 'Smith'}]
# => {:user=>{:title=>"Mr", :firstName=>"John", :lastName=>"Smith"}}
```