### PR TITLE
Add conditional (if)

### DIFF
--- a/lib/transproc/all.rb
+++ b/lib/transproc/all.rb
@@ -1,6 +1,7 @@
 require 'transproc'
 
 require 'transproc/coercions'
+require 'transproc/conditional'
 require 'transproc/array'
 require 'transproc/hash'
 require 'transproc/recursion'

--- a/lib/transproc/conditional.rb
+++ b/lib/transproc/conditional.rb
@@ -1,0 +1,5 @@
+module Transproc
+  register(:if) do |value, predicate, fn|
+    predicate[value] ? fn[value] : value
+  end
+end

--- a/spec/integration/conditional_spec.rb
+++ b/spec/integration/conditional_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'Conditional transformations with Transproc' do
+  describe 'if' do
+    let(:fn) { t(:if, ->(value) { value.is_a?(::String) }, t(:to_integer)) }
+
+    context 'when predicate returns truthy value' do
+      it 'applies the transformation and returns the result' do
+        input = '2'
+
+        expect(fn[input]).to eql(2)
+      end
+    end
+
+    context 'when predicate returns falsey value' do
+      it 'returns the original value' do
+        input = { 'foo' => 'bar' }
+
+        expect(fn[input]).to eql('foo' => 'bar')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow for conditional transformations, I think this is useful if combined with #11, this will make recursive hash transformations easier, i.e.

```ruby
require 'transproc/all'
module Transproc
  register(:strip) do |value|
    value.strip
  end
end

strip_string = Transproc(:if, ->(value) { value.is_a?(::String) }, Transproc(:strip))

fn = Transproc(:hash_recursion, Transproc(:transform_values, strip_string + Transproc(:if, ->(value) { value.is_a?(::Array) }, Transproc(:map_array, strip_string))) + Transproc(:symbolize_keys))
fn['user' => { 'first_name' => ' Gill ', 'last_name' => ' Bates ', email_addresses: [' me@gillbates.com ', 'gill.bates@gillbates.com '] }]
# => => {:user=>{:first_name=>"Gill", :last_name=>"Bates", :email_addresses=>["me@gillbates.com", "gill.bates@gillbates.com"]}}
```

Another example:

```ruby
require 'transproc/all'
module Transproc
  register(:swap) do |value, search, replace|
    value.tr(search, replace)
  end
end

swap_g_b = Transproc(:if, ->(value) { value.is_a?(::String) }, Transproc(:swap, 'GgBb', 'BbGg'))

fn = Transproc(:hash_recursion, Transproc(:transform_values, swap_g_b + Transproc(:if, ->(value) { value.is_a?(::Array) }, Transproc(:map_array, swap_g_b))) + Transproc(:symbolize_keys))
fn['user' => { 'first_name' => 'Gill', 'last_name' => 'Bates', email_addresses: ['me@gillbates.com', 'gill.bates@gillbates.com'] }]
# => {:user=>{:first_name=>"Bill", :last_name=>"Gates", :email_addresses=>["me@billgates.com", "bill.gates@billgates.com"]}}
```