### PR TITLE
Auto-register function via `method_added` hook

### DIFF
--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -10,18 +10,19 @@ module Transproc
     functions[name] = fn || block
   end
 
-  def register_from(mod)
-    (mod.public_methods - Module.public_methods).each do |meth|
-      Transproc.register(meth, mod.method(meth))
-    end
-  end
-
   def [](name)
     functions.fetch(name)
   end
 
   def functions
     @_functions ||= {}
+  end
+
+  module AutoRegister
+    def method_added(meth)
+      module_function meth
+      Transproc.register(meth, method(meth))
+    end
   end
 end
 

--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -18,7 +18,7 @@ module Transproc
     @_functions ||= {}
   end
 
-  module AutoRegister
+  module Functions
     def method_added(meth)
       module_function meth
       Transproc.register(meth, method(meth))

--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -1,6 +1,6 @@
 module Transproc
   module ArrayTransformations
-    extend AutoRegister
+    extend Functions
 
     def map_array(array, *fns)
       Transproc(:map_array!, *fns)[Array[*array]]

--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -1,6 +1,6 @@
 module Transproc
   module ArrayTransformations
-    module_function
+    extend AutoRegister
 
     def map_array(array, *fns)
       Transproc(:map_array!, *fns)[Array[*array]]
@@ -27,7 +27,5 @@ module Transproc
         root.merge(key => children)
       end
     end
-
-    Transproc.register_from(self)
   end
 end

--- a/lib/transproc/coercions.rb
+++ b/lib/transproc/coercions.rb
@@ -5,7 +5,7 @@ require 'bigdecimal/util'
 
 module Transproc
   module Coercions
-    extend AutoRegister
+    extend Functions
 
     TRUE_VALUES = [true, 1, '1', 'on', 't', 'true', 'y', 'yes'].freeze
     FALSE_VALUES = [false, 0, '0', 'off', 'f', 'false', 'n', 'no'].freeze

--- a/lib/transproc/coercions.rb
+++ b/lib/transproc/coercions.rb
@@ -5,7 +5,7 @@ require 'bigdecimal/util'
 
 module Transproc
   module Coercions
-    module_function
+    extend AutoRegister
 
     TRUE_VALUES = [true, 1, '1', 'on', 't', 'true', 'y', 'yes'].freeze
     FALSE_VALUES = [false, 0, '0', 'off', 'f', 'false', 'n', 'no'].freeze
@@ -49,7 +49,5 @@ module Transproc
     def to_datetime(value)
       DateTime.parse(value)
     end
-
-    Transproc.register_from(self)
   end
 end

--- a/lib/transproc/conditional.rb
+++ b/lib/transproc/conditional.rb
@@ -14,7 +14,7 @@ module Transproc
   #
   # @api public
   module Conditional
-    extend AutoRegister
+    extend Functions
 
     # Apply the transformation function to subject if the predicate returns true, or return un-modified
     #

--- a/lib/transproc/conditional.rb
+++ b/lib/transproc/conditional.rb
@@ -14,7 +14,7 @@ module Transproc
   #
   # @api public
   module Conditional
-    module_function
+    extend AutoRegister
 
     # Apply the transformation function to subject if the predicate returns true, or return un-modified
     #
@@ -32,7 +32,5 @@ module Transproc
     def guard(value, predicate, fn)
       predicate[value] ? fn[value] : value
     end
-
-    Transproc.register_from(self)
   end
 end

--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -15,7 +15,7 @@ module Transproc
   #
   # @api public
   module HashTransformations
-    extend AutoRegister
+    extend Functions
 
     # Map all keys in a hash with the provided transformation function
     #

--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -15,7 +15,7 @@ module Transproc
   #
   # @api public
   module HashTransformations
-    module_function
+    extend AutoRegister
 
     # Map all keys in a hash with the provided transformation function
     #
@@ -230,7 +230,5 @@ module Transproc
 
       hash
     end
-
-    Transproc.register_from(self)
   end
 end

--- a/lib/transproc/recursion.rb
+++ b/lib/transproc/recursion.rb
@@ -13,7 +13,7 @@ module Transproc
   #
   # @api public
   module Recursion
-    module_function
+    extend AutoRegister
 
     # Recursively apply the provided transformation function to an array
     #
@@ -68,7 +68,5 @@ module Transproc
 
       result
     end
-
-    Transproc.register_from(self)
   end
 end

--- a/lib/transproc/recursion.rb
+++ b/lib/transproc/recursion.rb
@@ -13,7 +13,7 @@ module Transproc
   #
   # @api public
   module Recursion
-    extend AutoRegister
+    extend Functions
 
     # Recursively apply the provided transformation function to an array
     #


### PR DESCRIPTION
Less setup ceremony (`module_function` and `register_from`).

:warning: This PR probably kills kittens. A LOT

/cc @solnic @AMHOL 