### PR TITLE
Remove splat from map_array

### DIFF
--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -2,12 +2,11 @@ module Transproc
   module ArrayTransformations
     module_function
 
-    def map_array(array, *fns)
-      Transproc(:map_array!, *fns)[Array[*array]]
+    def map_array(array, fn)
+      Transproc(:map_array!, fn)[Array[*array]]
     end
 
-    def map_array!(array, *fns)
-      fn = fns.size == 1 ? fns[0] : fns.reduce(:+)
+    def map_array!(array, fn)
       array.map! { |value| fn[value] }
     end
 

--- a/spec/integration/array_spec.rb
+++ b/spec/integration/array_spec.rb
@@ -56,7 +56,7 @@ describe 'Array transformations with Transproc' do
       wrap =
         t(
           :map_array,
-          t(:nest, :user, [:name, :title]),
+          t(:nest, :user, [:name, :title]) +
           t(:map_key, :user, t(:nest, :task, [:title]))
       )
 


### PR DESCRIPTION
Think it's better to have the user compose the function rather than support this interface, OTOH we could support it in `hash_recursion` etc. but I think it should be all-or-nothing and the same can easily be achieved with `compose`

```ruby
wrap =
  t(:map_array, t(:nest, :user, [:name, :title]) + t(:map_key, :user, t(:nest, :task, [:title])))
```