### PR TITLE
Transproc.register raises error on duplicate registration

### DIFF
--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -1,6 +1,7 @@
 require 'transproc/version'
 require 'transproc/function'
 require 'transproc/composer'
+require 'transproc/error'
 
 module Transproc
   module_function
@@ -18,6 +19,7 @@ module Transproc
   # @api public
   def register(*args, &block)
     name, fn = *args
+    raise Error.new("function #{name} is already defined") if functions.include?(name)
     functions[name] = fn || block
   end
 
@@ -27,7 +29,7 @@ module Transproc
   #
   # @api private
   def [](name)
-    functions.fetch(name)
+    functions[name] or raise Error.new("no registered function for #{name}")
   end
 
   # Function registry

--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -19,7 +19,7 @@ module Transproc
   # @api public
   def register(*args, &block)
     name, fn = *args
-    raise Error.new("function #{name} is already defined") if functions.include?(name)
+    raise FunctionAlreadyRegisteredError.new("function #{name} is already defined") if functions.include?(name)
     functions[name] = fn || block
   end
 
@@ -29,7 +29,7 @@ module Transproc
   #
   # @api private
   def [](name)
-    functions[name] or raise Error.new("no registered function for #{name}")
+    functions[name] or raise FunctionNotFoundError.new("no registered function for #{name}")
   end
 
   # Function registry

--- a/lib/transproc/error.rb
+++ b/lib/transproc/error.rb
@@ -1,3 +1,5 @@
 module Transproc
   Error = Class.new(StandardError)
+  FunctionNotFoundError = Class.new(Error)
+  FunctionAlreadyRegisteredError = Class.new(Error)
 end

--- a/lib/transproc/error.rb
+++ b/lib/transproc/error.rb
@@ -1,0 +1,3 @@
+module Transproc
+  Error = Class.new(StandardError)
+end

--- a/spec/integration/transproc_spec.rb
+++ b/spec/integration/transproc_spec.rb
@@ -35,9 +35,19 @@ describe Transproc do
       expect(result[:false]).to be(false)
     end
 
-    it 'raises a Transproc::Error if a function is already registered' do
+    it 'raises a Transproc::FunctionAlreadyRegisteredError if a function is already registered' do
       Transproc.register(:bogus){}
-      expect{ Transproc.register(:bogus){} }.to raise_error(Transproc::Error)
+      expect{ Transproc.register(:bogus){} }.to raise_error(Transproc::FunctionAlreadyRegisteredError)
+    end
+  end
+
+  describe 'nonextistent functions' do
+
+    it 'raises a Transproc::FunctionNotFoundError if asking for function that is non exsistent' do
+      expect{
+        Transproc(:i_do_not_exist)
+        fail('expected the :i_do_not_exist function to not exist')
+      }.to raise_error(Transproc::FunctionNotFoundError)
     end
   end
 end

--- a/spec/integration/transproc_spec.rb
+++ b/spec/integration/transproc_spec.rb
@@ -17,21 +17,27 @@ describe Transproc do
 
   describe 'function registration' do
     it 'allows registering functions by name' do
-      Transproc.register(:to_boolean, -> value { value == 'true' })
+      Transproc.register(:identity, -> value { value })
 
-      result = t(-> value { value.to_s }) >> t(:to_boolean)
+      value = 'hello world'
+
+      result = t(:identity)[value]
+
+      expect(result).to be(value)
+    end
+
+    it 'allows registering function by passing a block' do
+      Transproc.register(:to_boolean1) { |value| value == 'true' }
+
+      result = t(-> value { value.to_s }) >> t(:to_boolean1)
 
       expect(result[:true]).to be(true)
       expect(result[:false]).to be(false)
     end
 
-    it 'allows registering function by passing a block' do
-      Transproc.register(:to_boolean) { |value| value == 'true' }
-
-      result = t(-> value { value.to_s }) >> t(:to_boolean)
-
-      expect(result[:true]).to be(true)
-      expect(result[:false]).to be(false)
+    it 'raises a Transproc::Error if a function is already registered' do
+      Transproc.register(:bogus){}
+      expect{ Transproc.register(:bogus){} }.to raise_error(Transproc::Error)
     end
   end
 end


### PR DESCRIPTION
Transproc.register will raise an error if an function with
the given name is already registered.

Transproc[] will raise an error it cannot find the given function.