### PR TITLE
Wrap mapping errors in MalformedInputError

### DIFF
--- a/lib/transproc/error.rb
+++ b/lib/transproc/error.rb
@@ -2,4 +2,16 @@ module Transproc
   Error = Class.new(StandardError)
   FunctionNotFoundError = Class.new(Error)
   FunctionAlreadyRegisteredError = Class.new(Error)
+  MalformedInputError = Class.new(Error)
+
+  class MalformedInputError < Error
+    def initialize(function, value, error)
+      @function = function
+      @value = value
+      @original_error = error
+      super("failed to call function #{function} on #{value}, #{error}")
+    end
+
+    attr_reader :function, :value, :original_error
+  end
 end

--- a/lib/transproc/function.rb
+++ b/lib/transproc/function.rb
@@ -37,6 +37,8 @@ module Transproc
     # @api public
     def call(value)
       fn[value, *args]
+    rescue => ex
+      raise MalformedInputError.new(@fn, value, ex)
     end
     alias_method :[], :call
 

--- a/spec/integration/transproc_spec.rb
+++ b/spec/integration/transproc_spec.rb
@@ -49,4 +49,16 @@ describe Transproc do
       }.to raise_error(Transproc::FunctionNotFoundError)
     end
   end
+
+  describe 'handling malformed input' do
+    it 'raises a Transproc::MalformedInputError' do
+      Transproc.register(:im_dangerous, ->(){
+        raise ArgumentError.new('sorry, you got some bad apples in your input')
+      })
+
+      expect{
+        Transproc(:im_dangerous)[hello: 'world']
+      }.to raise_error(Transproc::MalformedInputError)
+    end
+  end
 end


### PR DESCRIPTION
This wraps any unexpected error in a ```Transproc::MalformedInputError```.
