### PR TITLE
Add `insert_key` transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * `:split` splits a hash to array by a list of values from a specified key of the hash (nepalez)
 * `:ungroup` is an inverse array transormation with respect to the `:group` (nepalez)
+* `:insert_key` (and `:insert_key!`) is the partial inversion of `:extract_key`.
+  The method converts array of values into array of tuples with given key (nepalez)
 
 ## v0.2.2 2015-05-22
 

--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -199,5 +199,33 @@ module Transproc
     def extract_key!(array, key)
       map_array!(array, -> v { v[key] })
     end
+
+    # Wraps every value of the array to tuple with given key
+    #
+    # The transformation partially inverses the `extract_key`.
+    #
+    # @example
+    #   fn = t(:insert_key, 'name')
+    #   fn.call ['Alice', 'Bob', nil]
+    #   # => [{ 'name' => 'Alice' }, { 'name' => 'Bob' }, { 'name' => nil }]
+    #
+    # @param [Array<Hash>] array The input array of hashes
+    # @param [Object] key The key to extract values by
+    #
+    # @return [Array]
+    #
+    # @api public
+    def insert_key(array, key)
+      insert_key!(Array[*array], key)
+    end
+
+    # Same as `insert_key` but mutates the array
+    #
+    # @see ArrayTransformations.insert_key
+    #
+    # @api public
+    def insert_key!(array, key)
+      map_array!(array, -> v { { key => v } })
+    end
   end
 end

--- a/spec/unit/array_transformations_spec.rb
+++ b/spec/unit/array_transformations_spec.rb
@@ -37,6 +37,44 @@ describe Transproc::ArrayTransformations do
     end
   end
 
+  describe '.insert_key' do
+    it 'wraps values to tuples with given key' do
+      insert_key = t(:insert_key, 'name')
+
+      original = ['Alice', 'Bob', nil]
+
+      input = original
+
+      output = [
+        { 'name' => 'Alice' },
+        { 'name' => 'Bob' },
+        { 'name' => nil }
+      ]
+
+      expect(insert_key[input]).to eql(output)
+      expect(input).to eql(original)
+    end
+  end
+
+  describe '.insert_key!' do
+    it 'wraps values to tuples with given key' do
+      insert_key = t(:insert_key!, 'name')
+
+      original = ['Alice', 'Bob', nil]
+
+      input = original
+
+      output = [
+        { 'name' => 'Alice' },
+        { 'name' => 'Bob' },
+        { 'name' => nil }
+      ]
+
+      expect(insert_key[input]).to eql(output)
+      expect(input).to eql(output)
+    end
+  end
+
   describe '.map_array' do
     it 'applies funtions to all values' do
       map = t(:map_array, t(:symbolize_keys))


### PR DESCRIPTION
The transformations partially inverse `extract_key` and `extract_key!` correspondingly
by wrapping array values to tuples with given key.

```ruby
  fn = Transproc.new(:hashify, 'name')
  source = ['Alice', nil]
  fn[source] # => [{ 'name' => 'Alice' }, { 'name' => nil }]
```

This is needed to implement the `unfold` mapper operation (as discussed in rom-rb/rom#200)