### PR TITLE
Add `add_tuple_keys` to array transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `:ungroup` is an inverse array transormation with respect to the `:group` (nepalez)
 * `:insert_key` (and `:insert_key!`) is the partial inversion of `:extract_key`.
   The method converts array of values into array of tuples with given key (nepalez)
+* `:add_keys` (and `:add_keys!`) adds missing keys to all tuples in array (nepalez)
 
 ## v0.2.2 2015-05-22
 

--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -227,5 +227,27 @@ module Transproc
     def insert_key!(array, key)
       map_array!(array, -> v { { key => v } })
     end
+
+    # Adds missing keys with nil value to all tuples in array
+    #
+    # @param [Array] keys
+    #
+    # @return [Array]
+    #
+    # @api public
+    #
+    def add_keys(array, keys)
+      add_keys!(Array[*array], keys)
+    end
+
+    # Same as `add_keys` but mutates the array
+    #
+    # @see ArrayTransformations.add_keys
+    #
+    # @api public
+    def add_keys!(array, keys)
+      base = keys.inject({}) { |a, e| a.merge(e => nil) }
+      map_array!(array, -> v { base.merge(v) })
+    end
   end
 end

--- a/spec/unit/array_transformations_spec.rb
+++ b/spec/unit/array_transformations_spec.rb
@@ -75,6 +75,42 @@ describe Transproc::ArrayTransformations do
     end
   end
 
+  describe '.add_keys' do
+    it 'returns a new array with missed keys added to tuples' do
+      add_keys = t(:add_keys, [:foo, :bar, :baz])
+
+      original = [{ foo: 'bar' }, { bar: 'baz' }]
+
+      input = original
+
+      output = [
+        { foo: 'bar', bar: nil, baz: nil },
+        { foo: nil, bar: 'baz', baz: nil }
+      ]
+
+      expect(add_keys[input]).to eql(output)
+      expect(input).to eql(original)
+    end
+  end
+
+  describe '.add_keys!' do
+    it 'adds missed keys to tuples' do
+      add_keys = t(:add_keys!, [:foo, :bar, :baz])
+
+      original = [{ foo: 'bar' }, { bar: 'baz' }]
+
+      input = original
+
+      output = [
+        { foo: 'bar', bar: nil, baz: nil },
+        { foo: nil, bar: 'baz', baz: nil }
+      ]
+
+      expect(add_keys[input]).to eql(output)
+      expect(input).to eql(output)
+    end
+  end
+
   describe '.map_array' do
     it 'applies funtions to all values' do
       map = t(:map_array, t(:symbolize_keys))


### PR DESCRIPTION
The transformation adds missing keys to all tuples:

```ruby
  fn = Transproc.new(:add_tuple_keys, [:foo, :bar])
  source = [{ foo: :foo }, { bar: :bar }]
  fn[source]
  # => [{ foo: foo, bar: nil }, { foo: nil, bar: :bar }]
```