### PR TITLE
Updated `split` transformation to support edge cases

### DIFF
--- a/spec/unit/array_transformations_spec.rb
+++ b/spec/unit/array_transformations_spec.rb
@@ -189,11 +189,25 @@ describe Transproc::ArrayTransformations do
   end
 
   describe '.ungroup' do
-    it 'returns a new array with ungrouped hashes' do
-      ungroup = t(:ungroup, :tasks, [:title])
+    subject(:ungroup) { t(:ungroup, :tasks, [:title]) }
 
+    it 'returns a new array with ungrouped hashes' do
       input = [{ name: 'Jane', tasks: [{ title: 'One' }, { title: 'Two' }] }]
       output = [{ name: 'Jane', title: 'One' }, { name: 'Jane', title: 'Two' }]
+
+      expect(ungroup[input]).to eql(output)
+    end
+
+    it 'returns an input with empty array removed' do
+      input = [{ name: 'Jane', tasks: [] }]
+      output = [{ name: 'Jane' }]
+
+      expect(ungroup[input]).to eql(output)
+    end
+
+    it 'returns an input when a key is absent' do
+      input = [{ name: 'Jane' }]
+      output = [{ name: 'Jane' }]
 
       expect(ungroup[input]).to eql(output)
     end

--- a/spec/unit/hash_transformations_spec.rb
+++ b/spec/unit/hash_transformations_spec.rb
@@ -362,8 +362,9 @@ describe Transproc::HashTransformations do
         tasks: [
           { title: 'sleep well', priority: 1   },
           { title: 'be nice',    priority: 2   },
-          { title: nil,          priority: 2   },
-          { title: 'be cool',    priority: nil }
+          {                      priority: 2   },
+          { title: 'be cool'                   },
+          {}
         ]
       }
     end
@@ -382,7 +383,7 @@ describe Transproc::HashTransformations do
         },
         {
           name: 'Joe', priority: nil,
-          tasks: [{ title: 'be cool' }]
+          tasks: [{ title: 'be cool' }, { title: nil }]
         }
       ]
 
@@ -396,21 +397,45 @@ describe Transproc::HashTransformations do
         { name: 'Joe', title: 'sleep well', priority: 1   },
         { name: 'Joe', title: 'be nice',    priority: 2   },
         { name: 'Joe', title: nil,          priority: 2   },
-        { name: 'Joe', title: 'be cool',    priority: nil }
+        { name: 'Joe', title: 'be cool',    priority: nil },
+        { name: 'Joe', title: nil,          priority: nil }
       ]
 
       expect(split[input]).to eql output
     end
 
-    it 'return an array of one tuple when there is nothing to split by' do
-      split = t(:split, :absent, [:priority, :title])
-      expect(split[input]).to eql [input]
+    it 'returns an array of one tuple with updated keys when there is nothing to split by' do
+      output = [
+        {
+          name: 'Joe',
+          tasks: [
+            { title: 'sleep well', priority: 1   },
+            { title: 'be nice',    priority: 2   },
+            { title: nil,          priority: 2   },
+            { title: 'be cool',    priority: nil },
+            { title: nil,          priority: nil }
+          ]
+        }
+      ]
 
       split = t(:split, :tasks, [])
-      expect(split[input]).to eql [input]
+      expect(split[input]).to eql output
 
       split = t(:split, :tasks, [:absent])
+      expect(split[input]).to eql output
+    end
+
+    it 'returns an array of initial tuple when attribute is absent' do
+      split = t(:split, :absent, [:priority, :title])
       expect(split[input]).to eql [input]
+    end
+
+    it 'ignores empty array' do
+      input = { name: 'Joe', tasks: [] }
+
+      split = t(:split, :tasks, [:title])
+
+      expect(split[input]).to eql [{ name: 'Joe' }]
     end
   end
 end


### PR DESCRIPTION
This is a reopened #39 after branch update.

When the attribute, selected for *splitting hash / ungrouping array* contains an empty array, both transformations just ignore it instead of returning empty values:

```ruby
  fn = Transproc.new(:split, :tasks, [:title])
  input = { name: "Joe", tasks: [] }
  fn[input]

  # Old behaviour:
  # => []

  # New behaviour (empty array ignored):
  # => [{ name: "Joe" }]
```

The transformation provides the regular output with missing keys inserted:

```ruby
  input = { name: "Joe", tasks: [{ title: "be nice" }, {}]

  # Old behaviour:
  # => [{ name: "Joe", title: "be nice" }, { name: "Joe" }]

  # New behaviour (missing keys added):
  # => [{ name: "Joe", title: "be nice" }, { name: "Joe", title: nil }]
```

All these weird edge cases are added to make sure the `ungroup` mapper operation in rom will return regular output.