### PR TITLE
Avoid circular require and enable warnings

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require spec_helper
+--warnings

--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -4,9 +4,6 @@ require 'transproc/functions'
 require 'transproc/composer'
 require 'transproc/error'
 
-require 'transproc/array'
-require 'transproc/hash'
-
 module Transproc
   module_function
 
@@ -47,6 +44,9 @@ module Transproc
     @_functions ||= {}
   end
 end
+
+require 'transproc/array'
+require 'transproc/hash'
 
 # Access registered functions
 #

--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -4,6 +4,9 @@ require 'transproc/functions'
 require 'transproc/composer'
 require 'transproc/error'
 
+require 'transproc/array'
+require 'transproc/hash'
+
 module Transproc
   module_function
 

--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -1,5 +1,6 @@
 require 'transproc/version'
 require 'transproc/function'
+require 'transproc/functions'
 require 'transproc/composer'
 require 'transproc/error'
 
@@ -41,27 +42,6 @@ module Transproc
   # @api private
   def functions
     @_functions ||= {}
-  end
-
-  # Function container extension
-  #
-  # @example
-  #   module MyTransformations
-  #     extend Transproc::Functions
-  #
-  #     def boom!(value)
-  #       "#{value} BOOM!"
-  #     end
-  #   end
-  #
-  #   Transproc(:boom!)['w00t!'] # => "w00t! BOOM!"
-  #
-  # @api public
-  module Functions
-    def method_added(meth)
-      module_function meth
-      Transproc.register(meth, method(meth))
-    end
   end
 end
 

--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -1,5 +1,3 @@
-require 'transproc/hash'
-
 module Transproc
   # Transformation functions for Array objects
   #
@@ -21,6 +19,8 @@ module Transproc
   # @api public
   module ArrayTransformations
     extend Functions
+
+    require 'transproc/hash' unless defined? Transproc::HashTransformations
 
     # Map array values using transformation function
     #

--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -20,8 +20,6 @@ module Transproc
   module ArrayTransformations
     extend Functions
 
-    require 'transproc/hash' unless defined? Transproc::HashTransformations
-
     # Map array values using transformation function
     #
     # @example

--- a/lib/transproc/functions.rb
+++ b/lib/transproc/functions.rb
@@ -1,0 +1,22 @@
+module Transproc
+  # Function container extension
+  #
+  # @example
+  #   module MyTransformations
+  #     extend Transproc::Functions
+  #
+  #     def boom!(value)
+  #       "#{value} BOOM!"
+  #     end
+  #   end
+  #
+  #   Transproc(:boom!)['w00t!'] # => "w00t! BOOM!"
+  #
+  # @api public
+  module Functions
+    def method_added(meth)
+      module_function meth
+      Transproc.register(meth, method(meth))
+    end
+  end
+end

--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -1,4 +1,3 @@
-require 'transproc/array'
 require 'transproc/coercions'
 
 module Transproc
@@ -17,6 +16,8 @@ module Transproc
   # @api public
   module HashTransformations
     extend Functions
+
+    require 'transproc/array' unless defined? Transproc::ArrayTransformations
 
     # Map all keys in a hash with the provided transformation function
     #

--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -17,8 +17,6 @@ module Transproc
   module HashTransformations
     extend Functions
 
-    require 'transproc/array' unless defined? Transproc::ArrayTransformations
-
     # Map all keys in a hash with the provided transformation function
     #
     # @example


### PR DESCRIPTION
:warning: :construction: :warning: 

Hi,

due to `warning: loading in progress, circular require considered harmful` ROM has silenced warnings in rom-rb/rom@fa542c4f0a952f6f880706c3b4dacd7ef2604efd.

I'd :heart: to enable warnings again :)

Here's my _hackish_ attempt to avoid circular requires in Transproc.

What's your opinion? Discuss! :dart:

/cc @solnic @nepalez @AMHOL @kwando

Kind regards,
  Peter
