### PR TITLE
Fix `unwrap` transformation

### DIFF
--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -271,9 +271,10 @@ module Transproc
     # @see HashTransformations.unwrap
     #
     # @api public
-    def unwrap!(hash, root, keys = nil)
+    def unwrap!(hash, root, selected = nil)
       if nested_hash = hash[root]
-        keys ||= nested_hash.keys
+        keys = nested_hash.keys
+        keys &= selected if selected
         hash.update(Hash[keys.zip(keys.map { |key| nested_hash.delete(key) })])
         hash.delete(root) if nested_hash.empty?
       end

--- a/spec/unit/hash_transformations_spec.rb
+++ b/spec/unit/hash_transformations_spec.rb
@@ -206,6 +206,17 @@ describe Transproc::HashTransformations do
 
       expect(input).to eql(output)
     end
+
+    it 'ignores unknown keys' do
+      unwrap = t(:unwrap!, 'wrapped', %w(one two three))
+
+      input = { 'wrapped' => { 'one' => nil, 'two' => false } }
+      output = { 'one' => nil, 'two' => false }
+
+      unwrap[input]
+
+      expect(input).to eql(output)
+    end
   end
 
   describe '.unwrap' do


### PR DESCRIPTION
The transformation should ignore unknown keys, that are not in the hash.

```ruby
  fn = Transproc.new(:unwrap, :values, %i(one two))
  source = { values: { one: "one" } }
  fn[source]

  # old behaviour:
  # => { one: "one", two: nil }

  # new behaviour:
  # => { one: "one" }
```

This is needed to make `unwrap` to work with deep nesting (I finally forced it :laughing: )