### PR TITLE
Mapper `group` operation can be applied step-by-step

### DIFF
--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -1,3 +1,5 @@
+require 'transproc/coercions'
+
 module Transproc
   # Transformation functions for Array objects
   #
@@ -88,12 +90,14 @@ module Transproc
       grouped = Hash.new { |h, k| h[k] = [] }
       array.each do |hash|
         hash = Hash[hash]
-        child = {}
-        keys.each { |k| child[k] = hash.delete(k) }
-        grouped[hash] << child
+
+        old_group = Transproc::Coercions.to_tuples(hash.delete(key))
+        new_group = keys.inject({}) { |a, e| a.merge(e => hash.delete(e)) }
+
+        grouped[hash] << old_group.map { |item| item.merge(new_group) }
       end
       grouped.map do |root, children|
-        root.merge(key => children)
+        root.merge(key => children.flatten)
       end
     end
 

--- a/lib/transproc/coercions.rb
+++ b/lib/transproc/coercions.rb
@@ -153,5 +153,25 @@ module Transproc
     def to_datetime(value)
       DateTime.parse(value)
     end
+
+    # Coerce value into an array containing tuples only
+    #
+    # If the source is not an array, or doesn't contain a tuple, returns
+    # an array with one empty tuple
+    #
+    # @example
+    #   Transproc(:to_tuples)[:foo]                  # => [{}]
+    #   Transproc(:to_tuples)[[]]                    # => [{}]
+    #   Transproc(:to_tuples)[[{ foo: :FOO, :bar }]] # => [{ foo: :FOO }]
+    #
+    # @param [Object] value
+    #
+    # @return [Array<Hash>]
+    #
+    def to_tuples(value)
+      array = value.is_a?(Array) ? Array[*value] : [{}]
+      array.select! { |item| item.is_a?(Hash) }
+      array.any? ? array : [{}]
+    end
   end
 end

--- a/spec/unit/array_transformations_spec.rb
+++ b/spec/unit/array_transformations_spec.rb
@@ -178,11 +178,54 @@ describe Transproc::ArrayTransformations do
   end
 
   describe '.group' do
-    it 'returns a new array with grouped hashes' do
-      group = t(:group, :tasks, [:title])
+    subject(:group) { t(:group, :tasks, [:title]) }
 
-      input = [{ name: 'Jane', title: 'One' }, { name: 'Jane', title: 'Two' }]
+    it 'returns a new array with grouped hashes' do
+      input  = [{ name: 'Jane', title: 'One' }, { name: 'Jane', title: 'Two' }]
       output = [{ name: 'Jane', tasks: [{ title: 'One' }, { title: 'Two' }] }]
+
+      expect(group[input]).to eql(output)
+    end
+
+    it 'updates the existing group' do
+      input  = [
+        {
+          name: 'Jane',
+          title: 'One',
+          tasks: [{ type: 'one' }, { type: 'two' }]
+        },
+        {
+          name: 'Jane',
+          title: 'Two',
+          tasks: [{ type: 'one' }, { type: 'two' }]
+        }
+      ]
+      output = [
+        {
+          name: 'Jane',
+          tasks: [
+            { title: 'One', type: 'one' },
+            { title: 'One', type: 'two' },
+            { title: 'Two', type: 'one' },
+            { title: 'Two', type: 'two' }
+          ]
+        }
+      ]
+
+      expect(group[input]).to eql(output)
+    end
+
+    it 'ingnores old values except for array of tuples' do
+      input  = [
+        { name: 'Jane', title: 'One',   tasks: [{ priority: 1 }, :wrong] },
+        { name: 'Jane', title: 'Two',   tasks: :wrong }
+      ]
+      output = [
+        {
+          name: 'Jane',
+          tasks: [{ title: 'One', priority: 1 }, { title: 'Two' }]
+        }
+      ]
 
       expect(group[input]).to eql(output)
     end
@@ -208,6 +251,34 @@ describe Transproc::ArrayTransformations do
     it 'returns an input when a key is absent' do
       input = [{ name: 'Jane' }]
       output = [{ name: 'Jane' }]
+
+      expect(ungroup[input]).to eql(output)
+    end
+
+    it 'ungroups array partially' do
+      input = [
+        {
+          name: 'Jane',
+          tasks: [
+            { title: 'One', type: 'one' },
+            { title: 'One', type: 'two' },
+            { title: 'Two', type: 'one' },
+            { title: 'Two', type: 'two' }
+          ]
+        }
+      ]
+      output = [
+        {
+          name: 'Jane',
+          title: 'One',
+          tasks: [{ type: 'one' }, { type: 'two' }]
+        },
+        {
+          name: 'Jane',
+          title: 'Two',
+          tasks: [{ type: 'one' }, { type: 'two' }]
+        }
+      ]
 
       expect(ungroup[input]).to eql(output)
     end

--- a/spec/unit/coercions_spec.rb
+++ b/spec/unit/coercions_spec.rb
@@ -79,4 +79,38 @@ describe Transproc::Coercions do
       end
     end
   end
+
+  describe '.to_tuples' do
+    subject(:to_tuples) { t(:to_tuples) }
+
+    context 'non-array' do
+      let(:input) { :foo }
+
+      it 'returns an array with one blank tuple' do
+        output = [{}]
+
+        expect(to_tuples[input]).to eql(output)
+      end
+    end
+
+    context 'empty array' do
+      let(:input) { [] }
+
+      it 'returns an array with one blank tuple' do
+        output = [{}]
+
+        expect(to_tuples[input]).to eql(output)
+      end
+    end
+
+    context 'array of tuples' do
+      let(:input) { [:foo, { bar: :BAZ }, :qux] }
+
+      it 'returns an array with tuples only' do
+        output = [{ bar: :BAZ }]
+
+        expect(to_tuples[input]).to eql(output)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Now the `group` operation does not rewrite an existing group,
but updates it with new keys, preserving the existing ones.
It acts like vector product:

```ruby
    fn = t(:group, :tasks, [:title]) }
    input  = [
      { name: 'Jane', title: 'One', tasks: [{ type: 'one' }, { type: 'two' }] },
      { name: 'Jane', title: 'Two', tasks: [{ type: 'one' }, { type: 'two' }] }
    ]

    # Old behaviour:

    fn[input]
    # => [{ name: 'Jane', tasks: [{ title: 'One' }, { title: 'Two' }] }]

    # New behaviour:

    fn[input]
    # => [
    #   {
    #     name: 'Jane',
    #     tasks: [
    #       { title: 'One', type: 'one' },
    #       { title: 'One', type: 'two' },
    #       { title: 'Two', type: 'one' },
    #       { title: 'Two', type: 'two' }
    #     ]
    #   }
    # ]
```