### PR TITLE
Both `nest` and `wrap` transformations add data to the existing subhash

### DIFF
--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -244,7 +244,9 @@ module Transproc
 
       if nest_keys.size > 0
         child = Hash[nest_keys.zip(nest_keys.map { |key| hash.delete(key) })]
-        hash.update(root => child)
+        old_nest = hash[root]
+        new_nest = old_nest.is_a?(Hash) ? old_nest.merge(child) : child
+        hash.update(root => new_nest)
       else
         hash.update(root => {})
       end

--- a/spec/unit/array_transformations_spec.rb
+++ b/spec/unit/array_transformations_spec.rb
@@ -175,6 +175,15 @@ describe Transproc::ArrayTransformations do
 
       expect(wrap[input]).to eql(output)
     end
+
+    it 'adds data to the existing tuples' do
+      wrap = t(:wrap, :task, [:title])
+
+      input  = [{ name: 'Jane', task: { priority: 1 }, title: 'One' }]
+      output = [{ name: 'Jane', task: { priority: 1, title: 'One' } }]
+
+      expect(wrap[input]).to eql(output)
+    end
   end
 
   describe '.group' do

--- a/spec/unit/hash_transformations_spec.rb
+++ b/spec/unit/hash_transformations_spec.rb
@@ -172,6 +172,28 @@ describe Transproc::HashTransformations do
       expect(input).to eql(output)
     end
 
+    it 'returns new hash with keys nested under the existing key' do
+      nest = t(:nest!, :baz, ['two'])
+
+      input  = { 'foo' => 'bar', baz: { 'one' => nil }, 'two' => false }
+      output = { 'foo' => 'bar', baz: { 'one' => nil, 'two' => false } }
+
+      nest[input]
+
+      expect(input).to eql(output)
+    end
+
+    it 'rewrites the existing key if its value is not a hash' do
+      nest = t(:nest!, :baz, ['two'])
+
+      input  = { 'foo' => 'bar', baz: 'one', 'two' => false }
+      output = { 'foo' => 'bar', baz: { 'two' => false } }
+
+      nest[input]
+
+      expect(input).to eql(output)
+    end
+
     it 'returns new hash with an empty hash under a new key when nest-keys are missing' do
       nest = t(:nest!, :baz, ['foo'])
 


### PR DESCRIPTION
Apply to `wrap` just the same logics as to `group`, allowing to wrap data step-by-step

1) `nest`

If the key, to which the data should be wrapped, is already exist
and contains a hash, then new data are added to that hash, while preserving
the existing data.

```ruby
  fn = t(:nest, :foo, :baz)
  source = { foo: { bar: :BAR }, baz: :BAZ }

  # Old behaviour
  fn[source] # => { foo: { baz: :BAZ } }

  # New behaviour
  fn[source] # => { foo: { bar: :BAR, baz: :BAZ } }
```

In case the value under the key is not a hash, new data rewrite the old ones
as before:

```ruby
  source = { foo: :FOO, baz: :BAZ }
  fn[source] # => { foo: { baz: :BAZ } }
```

2) `wrap`

The operation applies the updated `nest` to array of tuples.