### PR TITLE
Add `Transproc::Registry` module

### DIFF
--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -3,6 +3,7 @@ require 'transproc/function'
 require 'transproc/functions'
 require 'transproc/composer'
 require 'transproc/error'
+require 'transproc/registry'
 
 module Transproc
   module_function

--- a/lib/transproc/registry.rb
+++ b/lib/transproc/registry.rb
@@ -1,0 +1,124 @@
+module Transproc
+  # Container to define transproc functions in, and access them via `[]` method
+  # from the outside of the module
+  #
+  # @example
+  #   module FooMethods
+  #     extend Transproc::Registry
+  #
+  #     def foo(name, prefix)
+  #       [prefix, '_', name].join
+  #     end
+  #   end
+  #
+  #   fn = FooMethods[:foo, 'baz']
+  #   fn['qux'] # => 'qux_baz'
+  #
+  #   module BarMethods
+  #     # extend Transproc::Registry
+  #     include FooMethods
+  #
+  #     def bar(*args)
+  #       foo(*args).upcase
+  #     end
+  #   end
+  #
+  #   fn = BarMethods[:foo, 'baz']
+  #   fn['qux'] # => 'qux_baz'
+  #
+  #   fn = BarMethods[:bar, 'baz']
+  #   fn['qux'] # => 'QUX_BAZ'
+  #
+  # @api private
+  #
+  module Registry
+    # Builds the transproc function either from a Proc, or from the module method
+    #
+    # @param [Proc, Symbol] fn
+    #   Either a proc, or a name of the module's function to be wrapped to transproc
+    # @param [Object, Array] args
+    #   Args to be carried by the transproc
+    #
+    # @return [Transproc::Function]
+    #
+    # @alias :t
+    #
+    # @api public
+    #
+    def [](fn, *args)
+      fun = fn.is_a?(Proc) ? fn : method(fn).to_proc
+      Transproc::Function.new(fun, args: args)
+    end
+    alias_method :t, :[]
+
+    # Forwards the named method (transproc) to another module
+    #
+    # Allows using transprocs from other modules without including those
+    # modules as a whole
+    #
+    # @example
+    #   module Foo
+    #     extend Transproc::Registry
+    #
+    #     def foo(value)
+    #       value.upcase
+    #     end
+    #
+    #     def bar(value)
+    #       value.downcase
+    #     end
+    #  end
+    #
+    #  module Bar
+    #     extend Transproc::Registry
+    #
+    #     uses :foo, from: Foo, as: :baz
+    #     uses :bar, from: Foo
+    #  end
+    #
+    #  Bar[:baz]['Qux'] # => 'QUX'
+    #  Bar[:bar]['Qux'] # => 'qux'
+    #
+    # @param [String, Symbol] name
+    # @option [Class] :from The module to take the method from
+    # @option [String, Symbol] :as
+    #   The name of imported transproc inside the current module
+    #
+    # @return [undefined]
+    #
+    def uses(name, options = {})
+      source   = options.fetch(:from)
+      new_name = options.fetch(:as, name)
+      define_method(new_name) { |*args| source.__send__(name, *args) }
+    end
+
+    # @api private
+    def self.extended(target)
+      target.send(:extend, ClassMethods)
+    end
+
+    # @api private
+    module ClassMethods
+      # Makes `[]` and all functions defined in the included modules
+      # accessible in their receiver
+      #
+      def included(other)
+        other.extend(Transproc::Registry, self)
+      end
+
+      # Makes newly module-defined functions accessible via `[]` method
+      # by adding it to the module's eigenclass
+      #
+      def method_added(name)
+        module_function(name)
+      end
+
+      # Makes undefined methods inaccessible via `[]` method by
+      # undefining it from the module's eigenclass
+      #
+      def method_undefined(name)
+        singleton_class.__send__(:undef_method, name)
+      end
+    end
+  end
+end

--- a/spec/unit/registry_spec.rb
+++ b/spec/unit/registry_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe Transproc::Registry do
+  before do
+    module FooModule
+      extend Transproc::Registry
+
+      def foo(value, prefix)
+        [prefix, '_', value].join
+      end
+    end
+
+    module BarModule
+      include FooModule
+
+      def bar(*args)
+        foo(*args).upcase
+      end
+    end
+
+    module BazModule
+      extend Transproc::Registry
+    end
+  end
+
+  describe '.[]' do
+    it 'builds function from the method' do
+      fn = ::FooModule[:foo, 'baz']
+
+      expect(fn['qux']).to eql 'baz_qux'
+    end
+
+    it 'builds function from the proc' do
+      fun = -> value, prefix { [prefix, '_', value].join }
+      fn  = ::FooModule[fun, 'baz']
+
+      expect(fn['qux']).to eql 'baz_qux'
+    end
+
+    it 'builds function using methods from included modules' do
+      fn = ::BarModule[:bar, 'baz']
+
+      expect(fn['qux']).to eql 'BAZ_QUX'
+    end
+
+    it 'can access methods from included modules directly' do
+      fn = ::BarModule[:foo, 'baz']
+
+      expect(fn['qux']).to eql 'baz_qux'
+    end
+
+    it 'cannot access undefined methods' do
+      module ::BarModule
+        undef_method :foo
+      end
+
+      expect { ::BarModule[:foo, 'baz'] }.to raise_error
+    end
+  end
+
+  describe '.uses' do
+    it 'forwards methods to another module directly' do
+      expect { ::BazModule[:baz, 'baz'] }.to raise_error
+
+      module BazModule
+        uses :foo, as: :ffoo, from: FooModule
+        uses :bar, from: BarModule
+      end
+
+      ffoo = ::BazModule[:ffoo, 'baz']
+      bar  = ::BazModule[:bar, 'baz']
+
+      expect(ffoo['qux']).to eql 'baz_qux'
+      expect(bar['qux']).to eql 'BAZ_QUX'
+    end
+  end
+
+  describe '#t' do
+    it 'is an alias for .[]' do
+      module FooModule
+        def qux(value, *args)
+          t(:foo, *args)[value]
+        end
+      end
+
+      fn = ::FooModule[:foo, 'baz']
+
+      expect(fn['qux']).to eql 'baz_qux'
+    end
+  end
+
+  after { Object.send :remove_const, :BazModule }
+  after { Object.send :remove_const, :BarModule }
+  after { Object.send :remove_const, :FooModule }
+end


### PR DESCRIPTION
**ATTENTION! ВНИМАНИЕ! UWAGA!
This is still an experimental feature concering #45. Discussion needed!**

The module defines method `.[]` to build transproc functions
from its instance methods. Unlike `Transproc(fn, *args)` it uses
square brackets for the same purpose.

The module can be used to define transproc functions locally:

```ruby
  module FooModule
    extend Transproc::Registry

    def foo(name, prefix)
      [prefix, '_', name].join
    end
  end

  fn = FooModule[:foo, 'baz']
  fn['qux'] # => 'baz_qux'
```

To access transprocs from another module, the later should be included:

```ruby
  module BarModule
    # extend Transproc::Registry
    include FooModule

    def bar(*args)
      foo(*args).upcase
    end
  end

  fn = BarModule[:bar, 'baz']
  fn['qux'] # => 'BAZ_QUX'

  fn = BarModule[:foo, 'baz']
  fn['qux'] # => 'baz_qux'
```
You can also undefine selected methods
```ruby
  module BarModule
    undef_method :foo
  end

  fn = BarModule[:foo, 'baz'] # => #<NameError ...>
```