### PR TITLE
Switch to singleton methods

### DIFF
--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -6,9 +6,12 @@ require 'transproc/error'
 require 'transproc/registry'
 
 module Transproc
-  extend Registry
-
-  module_function
+  # Function registry
+  #
+  # @api private
+  def self.functions
+    @_functions ||= {}
+  end
 
   # Register a new function
   #
@@ -21,9 +24,9 @@ module Transproc
   # @return [Function]
   #
   # @api public
-  def register(*args, &block)
+  def self.register(*args, &block)
     name, fn = *args
-    if functions.include?(name)
+    if functions.include? name
       raise FunctionAlreadyRegisteredError, "Function #{name} is already defined"
     end
     functions[name] = fn || block
@@ -34,24 +37,10 @@ module Transproc
   # @param [Symbol] name The name of the registered function
   #
   # @api private
-  def [](name, *args)
-    fn =
-      if functions.key?(name)
-        functions[name]
-      else
-        begin
-          super
-        rescue NameError;end
-      end
-    raise FunctionNotFoundError, "No registered function for #{name}" unless fn
-    fn
-  end
-
-  # Function registry
-  #
-  # @api private
-  def functions
-    @_functions ||= {}
+  def self.[](name, *args)
+    functions.fetch(name) {
+      raise FunctionNotFoundError, "No globally registered function for #{name}"
+    }
   end
 end
 

--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -36,7 +36,7 @@ module Transproc
     # @return [Array]
     #
     # @api public
-    def map_array(array, fn)
+    def self.map_array(array, fn)
       map_array!(Array[*array], fn)
     end
 
@@ -45,7 +45,7 @@ module Transproc
     # @see ArrayTransformations.map_array
     #
     # @api public
-    def map_array!(array, fn)
+    def self.map_array!(array, fn)
       array.map! { |value| fn[value] }
     end
 
@@ -64,7 +64,7 @@ module Transproc
     # @return [Array]
     #
     # @api public
-    def wrap(array, key, keys)
+    def self.wrap(array, key, keys)
       map_array(array, Transproc(:nest, key, keys))
     end
 
@@ -86,7 +86,7 @@ module Transproc
     # @return [Array]
     #
     # @api public
-    def group(array, key, keys)
+    def self.group(array, key, keys)
       grouped = Hash.new { |h, k| h[k] = [] }
       array.each do |hash|
         hash = Hash[hash]
@@ -121,7 +121,7 @@ module Transproc
     # @return [Array]
     #
     # @api public
-    def ungroup(array, key, keys)
+    def self.ungroup(array, key, keys)
       array.flat_map { |item| HashTransformations.split(item, key, keys) }
     end
 
@@ -139,7 +139,7 @@ module Transproc
     # @return [Array<Hash>]
     #
     # @api public
-    def combine(array, mappings)
+    def self.combine(array, mappings)
       root, groups = array
 
       cache = Hash.new { |h, k| h[k] = {} }
@@ -189,7 +189,7 @@ module Transproc
     # @return [Array]
     #
     # @api public
-    def extract_key(array, key)
+    def self.extract_key(array, key)
       extract_key!(Array[*array], key)
     end
 
@@ -198,7 +198,7 @@ module Transproc
     # @see ArrayTransformations.extract_key
     #
     # @api public
-    def extract_key!(array, key)
+    def self.extract_key!(array, key)
       map_array!(array, -> v { v[key] })
     end
 
@@ -217,7 +217,7 @@ module Transproc
     # @return [Array]
     #
     # @api public
-    def insert_key(array, key)
+    def self.insert_key(array, key)
       insert_key!(Array[*array], key)
     end
 
@@ -226,7 +226,7 @@ module Transproc
     # @see ArrayTransformations.insert_key
     #
     # @api public
-    def insert_key!(array, key)
+    def self.insert_key!(array, key)
       map_array!(array, -> v { { key => v } })
     end
 
@@ -238,7 +238,7 @@ module Transproc
     #
     # @api public
     #
-    def add_keys(array, keys)
+    def self.add_keys(array, keys)
       add_keys!(Array[*array], keys)
     end
 
@@ -247,7 +247,7 @@ module Transproc
     # @see ArrayTransformations.add_keys
     #
     # @api public
-    def add_keys!(array, keys)
+    def self.add_keys!(array, keys)
       base = keys.inject({}) { |a, e| a.merge(e => nil) }
       map_array!(array, -> v { base.merge(v) })
     end

--- a/lib/transproc/array.rb
+++ b/lib/transproc/array.rb
@@ -1,4 +1,5 @@
 require 'transproc/coercions'
+require 'transproc/hash'
 
 module Transproc
   # Transformation functions for Array objects
@@ -65,7 +66,8 @@ module Transproc
     #
     # @api public
     def self.wrap(array, key, keys)
-      map_array(array, Transproc(:nest, key, keys))
+      nest = HashTransformations[:nest, key, keys]
+      map_array(array, nest)
     end
 
     # Group array values using provided root key and value keys
@@ -91,7 +93,7 @@ module Transproc
       array.each do |hash|
         hash = Hash[hash]
 
-        old_group = Transproc::Coercions.to_tuples(hash.delete(key))
+        old_group = Coercions.to_tuples(hash.delete(key))
         new_group = keys.inject({}) { |a, e| a.merge(e => hash.delete(e)) }
 
         grouped[hash] << old_group.map { |item| item.merge(new_group) }
@@ -251,9 +253,9 @@ module Transproc
       base = keys.inject({}) { |a, e| a.merge(e => nil) }
       map_array!(array, -> v { base.merge(v) })
     end
-  end
 
-  ArrayTransformations.singleton_methods(false).each do |meth|
-    uses meth, from: ArrayTransformations
+    # @deprecated Register methods globally
+    (methods - Registry.methods - Registry.instance_methods)
+      .each { |name| Transproc.register name, t(name) }
   end
 end

--- a/lib/transproc/class.rb
+++ b/lib/transproc/class.rb
@@ -48,8 +48,9 @@ module Transproc
       end
       object
     end
-  end
 
-  import :constructor_inject, from: ClassTransformations
-  import :set_ivars, from: ClassTransformations
+    # @deprecated Register methods globally
+    (methods - Registry.methods - Registry.instance_methods)
+      .each { |name| Transproc.register name, t(name) }
+  end
 end

--- a/lib/transproc/class.rb
+++ b/lib/transproc/class.rb
@@ -26,7 +26,7 @@ module Transproc
     # @return [Object] An instance of the given klass
     #
     # @api public
-    def constructor_inject(*args, klass)
+    def self.constructor_inject(*args, klass)
       klass.new(*args)
     end
 
@@ -41,7 +41,7 @@ module Transproc
     # @return [Object]
     #
     # @api public
-    def set_ivars(ivar_hash, klass)
+    def self.set_ivars(ivar_hash, klass)
       object = klass.allocate
       ivar_hash.each do |ivar_name, ivar_value|
         object.instance_variable_set("@#{ivar_name}", ivar_value)
@@ -50,6 +50,6 @@ module Transproc
     end
   end
 
-  uses :constructor_inject, from: ClassTransformations
-  uses :set_ivars, from: ClassTransformations
+  import :constructor_inject, from: ClassTransformations
+  import :set_ivars, from: ClassTransformations
 end

--- a/lib/transproc/coercions.rb
+++ b/lib/transproc/coercions.rb
@@ -173,9 +173,9 @@ module Transproc
       array.select! { |item| item.is_a?(Hash) }
       array.any? ? array : [{}]
     end
-  end
 
-  Coercions.singleton_methods(false).each do |meth|
-    uses meth, from: Coercions
+    # @deprecated Register methods globally
+    (methods - Registry.methods - Registry.instance_methods)
+      .each { |name| Transproc.register name, t(name) }
   end
 end

--- a/lib/transproc/coercions.rb
+++ b/lib/transproc/coercions.rb
@@ -28,7 +28,7 @@ module Transproc
     # @return [String]
     #
     # @api public
-    def to_string(value)
+    def self.to_string(value)
       value.to_s
     end
 
@@ -43,7 +43,7 @@ module Transproc
     # @return [Symbol]
     #
     # @api public
-    def to_symbol(value)
+    def self.to_symbol(value)
       value.to_sym
     end
 
@@ -58,7 +58,7 @@ module Transproc
     # @return [Integer]
     #
     # @api public
-    def to_integer(value)
+    def self.to_integer(value)
       value.to_i
     end
 
@@ -73,7 +73,7 @@ module Transproc
     # @return [Float]
     #
     # @api public
-    def to_float(value)
+    def self.to_float(value)
       value.to_f
     end
 
@@ -88,7 +88,7 @@ module Transproc
     # @return [Decimal]
     #
     # @api public
-    def to_decimal(value)
+    def self.to_decimal(value)
       value.to_d
     end
 
@@ -105,7 +105,7 @@ module Transproc
     # @return [TrueClass,FalseClass]
     #
     # @api public
-    def to_boolean(value)
+    def self.to_boolean(value)
       BOOLEAN_MAP.fetch(value)
     end
 
@@ -120,7 +120,7 @@ module Transproc
     # @return [Date]
     #
     # @api public
-    def to_date(value)
+    def self.to_date(value)
       Date.parse(value)
     end
 
@@ -135,7 +135,7 @@ module Transproc
     # @return [Time]
     #
     # @api public
-    def to_time(value)
+    def self.to_time(value)
       Time.parse(value)
     end
 
@@ -150,7 +150,7 @@ module Transproc
     # @return [DateTime]
     #
     # @api public
-    def to_datetime(value)
+    def self.to_datetime(value)
       DateTime.parse(value)
     end
 
@@ -168,7 +168,7 @@ module Transproc
     #
     # @return [Array<Hash>]
     #
-    def to_tuples(value)
+    def self.to_tuples(value)
       array = value.is_a?(Array) ? Array[*value] : [{}]
       array.select! { |item| item.is_a?(Hash) }
       array.any? ? array : [{}]

--- a/lib/transproc/conditional.rb
+++ b/lib/transproc/conditional.rb
@@ -28,7 +28,7 @@ module Transproc
     # @return [Mixed]
     #
     # @api public
-    def guard(value, predicate, fn)
+    def self.guard(value, predicate, fn)
       predicate[value] ? fn[value] : value
     end
 
@@ -48,7 +48,7 @@ module Transproc
     # @return [Object]
     #
     # @api public
-    def is(value, type, fn)
+    def self.is(value, type, fn)
       guard(value, -> v { v.is_a?(type) }, fn)
     end
   end

--- a/lib/transproc/conditional.rb
+++ b/lib/transproc/conditional.rb
@@ -51,9 +51,9 @@ module Transproc
     def self.is(value, type, fn)
       guard(value, -> v { v.is_a?(type) }, fn)
     end
-  end
 
-  Conditional.singleton_methods(false).each do |meth|
-    uses meth, from: Conditional
+    # @deprecated Register methods globally
+    (methods - Registry.methods - Registry.instance_methods)
+      .each { |name| Transproc.register name, t(name) }
   end
 end

--- a/lib/transproc/function.rb
+++ b/lib/transproc/function.rb
@@ -22,10 +22,18 @@ module Transproc
     # @api private
     attr_reader :args
 
+    # @!attribute [r] name
+    #
+    # @return [<type] The name of the function
+    #
+    # @api public
+    attr_reader :name
+
     # @api private
     def initialize(fn, options = {})
       @fn = fn
       @args = options.fetch(:args, [])
+      @name = options.fetch(:name, fn)
     end
 
     # Call the wrapped proc
@@ -38,7 +46,7 @@ module Transproc
     def call(*value)
       fn[*value, *args]
     rescue => e
-      raise MalformedInputError.new(@fn, value, e)
+      raise MalformedInputError.new(@name, value, e)
     end
     alias_method :[], :call
 
@@ -63,8 +71,7 @@ module Transproc
     #
     # @api public
     def to_ast
-      identifier = fn.instance_of?(Proc) ? fn : fn.name
-      [identifier, args]
+      [name, args]
     end
   end
 end

--- a/lib/transproc/function.rb
+++ b/lib/transproc/function.rb
@@ -23,9 +23,9 @@ module Transproc
     attr_reader :args
 
     # @api private
-    def initialize(fn, options)
+    def initialize(fn, options = {})
       @fn = fn
-      @args = options[:args]
+      @args = options.fetch(:args, [])
     end
 
     # Call the wrapped proc

--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -63,7 +63,7 @@ module Transproc
     #
     # @api public
     def self.symbolize_keys!(hash)
-      map_keys!(hash, Transproc(:to_symbol).fn)
+      map_keys!(hash, Coercions[:to_symbol].fn)
     end
 
     # Stringify all keys in a hash
@@ -87,7 +87,7 @@ module Transproc
     #
     # @api public
     def self.stringify_keys!(hash)
-      map_keys!(hash, Transproc(:to_string).fn)
+      map_keys!(hash, Coercions[:to_string].fn)
     end
 
     # Map all values in a hash using transformation function
@@ -356,9 +356,9 @@ module Transproc
       list = list.map { |item| item.merge(reject_keys(hash, [key])) }
       ArrayTransformations.add_keys(list, ungrouped)
     end
-  end
 
-  HashTransformations.singleton_methods(false).each do |meth|
-    uses meth, from: HashTransformations
+    # @deprecated Register methods globally
+    (methods - Registry.instance_methods - Registry.methods)
+      .each { |name| Transproc.register name, t(name) }
   end
 end

--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -28,7 +28,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def map_keys(hash, fn)
+    def self.map_keys(hash, fn)
       map_keys!(Hash[hash], fn)
     end
 
@@ -37,7 +37,7 @@ module Transproc
     # @see HashTransformations.map_keys
     #
     # @api public
-    def map_keys!(hash, fn)
+    def self.map_keys!(hash, fn)
       hash.keys.each { |key| hash[fn[key]] = hash.delete(key) }
       hash
     end
@@ -53,7 +53,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def symbolize_keys(hash)
+    def self.symbolize_keys(hash)
       symbolize_keys!(Hash[hash])
     end
 
@@ -62,7 +62,7 @@ module Transproc
     # @see HashTransformations.symbolize_keys!
     #
     # @api public
-    def symbolize_keys!(hash)
+    def self.symbolize_keys!(hash)
       map_keys!(hash, Transproc(:to_symbol).fn)
     end
 
@@ -77,7 +77,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def stringify_keys(hash)
+    def self.stringify_keys(hash)
       stringify_keys!(Hash[hash])
     end
 
@@ -86,7 +86,7 @@ module Transproc
     # @see HashTransformations.stringify_keys
     #
     # @api public
-    def stringify_keys!(hash)
+    def self.stringify_keys!(hash)
       map_keys!(hash, Transproc(:to_string).fn)
     end
 
@@ -101,7 +101,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def map_values(hash, fn)
+    def self.map_values(hash, fn)
       map_values!(Hash[hash], fn)
     end
 
@@ -114,7 +114,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def map_values!(hash, fn)
+    def self.map_values!(hash, fn)
       hash.each { |key, value| hash[key] = fn[value] }
       hash
     end
@@ -131,7 +131,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def rename_keys(hash, mapping)
+    def self.rename_keys(hash, mapping)
       rename_keys!(Hash[hash], mapping)
     end
 
@@ -140,7 +140,7 @@ module Transproc
     # @see HashTransformations.rename_keys
     #
     # @api public
-    def rename_keys!(hash, mapping)
+    def self.rename_keys!(hash, mapping)
       mapping.each { |k, v| hash[v] = hash.delete(k) }
       hash
     end
@@ -157,7 +157,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def reject_keys(hash, keys)
+    def self.reject_keys(hash, keys)
       reject_keys!(Hash[hash], keys)
     end
 
@@ -166,7 +166,7 @@ module Transproc
     # @see HashTransformations.reject_keys
     #
     # @api public
-    def reject_keys!(hash, keys)
+    def self.reject_keys!(hash, keys)
       hash.reject { |k, _| keys.include?(k) }
     end
 
@@ -182,7 +182,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def accept_keys(hash, keys)
+    def self.accept_keys(hash, keys)
       accept_keys!(Hash[hash], keys)
     end
 
@@ -191,7 +191,7 @@ module Transproc
     # @see HashTransformations.accept
     #
     # @api public
-    def accept_keys!(hash, keys)
+    def self.accept_keys!(hash, keys)
       reject_keys!(hash, hash.keys - keys)
     end
 
@@ -206,7 +206,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def map_value(hash, key, fn)
+    def self.map_value(hash, key, fn)
       hash.merge(key => fn[hash[key]])
     end
 
@@ -215,7 +215,7 @@ module Transproc
     # @see HashTransformations.map_value
     #
     # @api public
-    def map_value!(hash, key, fn)
+    def self.map_value!(hash, key, fn)
       hash.update(key => fn[hash[key]])
     end
 
@@ -230,7 +230,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def nest(hash, key, keys)
+    def self.nest(hash, key, keys)
       nest!(Hash[hash], key, keys)
     end
 
@@ -239,7 +239,7 @@ module Transproc
     # @see HashTransformations.nest
     #
     # @api public
-    def nest!(hash, root, keys)
+    def self.nest!(hash, root, keys)
       nest_keys = hash.keys & keys
 
       if nest_keys.size > 0
@@ -263,7 +263,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def unwrap(hash, root, keys = nil)
+    def self.unwrap(hash, root, keys = nil)
       copy = Hash[hash].merge(root => Hash[hash[root]])
       unwrap!(copy, root, keys)
     end
@@ -273,7 +273,7 @@ module Transproc
     # @see HashTransformations.unwrap
     #
     # @api public
-    def unwrap!(hash, root, selected = nil)
+    def self.unwrap!(hash, root, selected = nil)
       if nested_hash = hash[root]
         keys = nested_hash.keys
         keys &= selected if selected
@@ -303,7 +303,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def fold(hash, key, tuple_key)
+    def self.fold(hash, key, tuple_key)
       fold!(Hash[hash], key, tuple_key)
     end
 
@@ -312,7 +312,7 @@ module Transproc
     # @see HashTransformations.fold
     #
     # @api public
-    def fold!(hash, key, tuple_key)
+    def self.fold!(hash, key, tuple_key)
       hash.update(key => ArrayTransformations.extract_key(hash[key], tuple_key))
     end
 
@@ -344,7 +344,7 @@ module Transproc
     # @return [Array<Hash>]
     #
     # @api public
-    def split(hash, key, keys)
+    def self.split(hash, key, keys)
       list = Array(hash[key])
       return [hash.reject { |k, _| k == key }] if list.empty?
 

--- a/lib/transproc/recursion.rb
+++ b/lib/transproc/recursion.rb
@@ -43,7 +43,7 @@ module Transproc
     # @return [Enumerable]
     #
     # @api public
-    def recursion(value, fn)
+    def self.recursion(value, fn)
       result = fn[value]
       guarded = IF_ENUMERABLE[-> v { recursion(v, fn) }]
 
@@ -74,7 +74,7 @@ module Transproc
     # @return [Array]
     #
     # @api public
-    def array_recursion(value, fn)
+    def self.array_recursion(value, fn)
       result = fn[value]
       guarded = IF_ARRAY[-> v { array_recursion(v, fn) }]
 
@@ -96,7 +96,7 @@ module Transproc
     # @return [Hash]
     #
     # @api public
-    def hash_recursion(value, fn)
+    def self.hash_recursion(value, fn)
       result = fn[value]
       guarded = IF_HASH[-> v { hash_recursion(v, fn) }]
 

--- a/lib/transproc/recursion.rb
+++ b/lib/transproc/recursion.rb
@@ -17,11 +17,11 @@ module Transproc
   module Recursion
     extend Registry
 
-    IF_ENUMERABLE = -> fn { Transproc(:is, Enumerable, fn) }
+    IF_ENUMERABLE = -> fn { Conditional[:is, Enumerable, fn] }
 
-    IF_ARRAY = -> fn { Transproc(:is, Array, fn) }
+    IF_ARRAY = -> fn { Conditional[:is, Array, fn] }
 
-    IF_HASH = -> fn { Transproc(:is, Hash, fn) }
+    IF_HASH = -> fn { Conditional[:is, Hash, fn] }
 
     # Recursively apply the provided transformation function to an enumerable
     #
@@ -106,9 +106,9 @@ module Transproc
 
       result
     end
-  end
 
-  Recursion.singleton_methods(false).each do |meth|
-    uses meth, from: Recursion
+    # @deprecated Register methods globally
+    (methods - Registry.methods - Registry.instance_methods)
+      .each { |name| Transproc.register name, t(name) }
   end
 end

--- a/lib/transproc/registry.rb
+++ b/lib/transproc/registry.rb
@@ -49,12 +49,8 @@ module Transproc
     # @alias :t
     #
     def [](fn, *args)
-      if fn.is_a?(Proc)
-        function = fn
-      else
-        function = send(:method, fn).to_proc
-      end
-      Function.new(function, args: args)
+      function = fn.is_a?(Proc) ? fn : send(:method, fn).to_proc
+      Function.new(function, args: args, name: fn)
     end
     alias_method :t, :[]
 

--- a/spec/unit/array_transformations_spec.rb
+++ b/spec/unit/array_transformations_spec.rb
@@ -294,8 +294,8 @@ describe Transproc::ArrayTransformations do
   end
 
   describe '.combine' do
-    let(:input) do
-      [
+    it 'merges hashes from arrays using provided join keys' do
+      input = [
         # parent users
         [
           { name: 'Jane', email: 'jane@doe.org' },
@@ -319,10 +319,8 @@ describe Transproc::ArrayTransformations do
           ]
         ]
       ]
-    end
 
-    let(:output) do
-      [
+      output = [
         { name: 'Jane', email: 'jane@doe.org', tasks: [
           { user: 'Jane', title: 'One', tags: [{ task: 'One', tag: 'red' }] },
           { user: 'Jane', title: 'Two', tags: [] }]
@@ -331,9 +329,7 @@ describe Transproc::ArrayTransformations do
           { user: 'Joe', title: 'Three', tags: [{ task: 'Three', tag: 'blue' }] }]
         }
       ]
-    end
 
-    it 'merges hashes from arrays using provided join keys' do
       combine = t(:combine, [
         [:tasks, { name: :user }, [[:tags, title: :task]]]
       ])

--- a/spec/unit/array_transformations_spec.rb
+++ b/spec/unit/array_transformations_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe Transproc::ArrayTransformations do
+  let(:hashes) { Transproc::HashTransformations }
+
   describe '.extract_key' do
     it 'extracts values by key from all hashes' do
-      extract_key = t(:extract_key, 'name')
+      extract_key = described_class.t(:extract_key, 'name')
 
       original = [
         { 'name' => 'Alice', 'role' => 'sender' },
@@ -22,7 +24,7 @@ describe Transproc::ArrayTransformations do
 
   describe '.extract_key!' do
     it 'extracts values by key from all hashes' do
-      extract_key = t(:extract_key!, 'name')
+      extract_key = described_class.t(:extract_key!, 'name')
 
       input = [
         { 'name' => 'Alice', 'role' => 'sender' },
@@ -39,7 +41,7 @@ describe Transproc::ArrayTransformations do
 
   describe '.insert_key' do
     it 'wraps values to tuples with given key' do
-      insert_key = t(:insert_key, 'name')
+      insert_key = described_class.t(:insert_key, 'name')
 
       original = ['Alice', 'Bob', nil]
 
@@ -58,7 +60,7 @@ describe Transproc::ArrayTransformations do
 
   describe '.insert_key!' do
     it 'wraps values to tuples with given key' do
-      insert_key = t(:insert_key!, 'name')
+      insert_key = described_class.t(:insert_key!, 'name')
 
       original = ['Alice', 'Bob', nil]
 
@@ -77,7 +79,7 @@ describe Transproc::ArrayTransformations do
 
   describe '.add_keys' do
     it 'returns a new array with missed keys added to tuples' do
-      add_keys = t(:add_keys, [:foo, :bar, :baz])
+      add_keys = described_class.t(:add_keys, [:foo, :bar, :baz])
 
       original = [{ foo: 'bar' }, { bar: 'baz' }]
 
@@ -95,7 +97,7 @@ describe Transproc::ArrayTransformations do
 
   describe '.add_keys!' do
     it 'adds missed keys to tuples' do
-      add_keys = t(:add_keys!, [:foo, :bar, :baz])
+      add_keys = described_class.t(:add_keys!, [:foo, :bar, :baz])
 
       original = [{ foo: 'bar' }, { bar: 'baz' }]
 
@@ -113,7 +115,7 @@ describe Transproc::ArrayTransformations do
 
   describe '.map_array' do
     it 'applies funtions to all values' do
-      map = t(:map_array, t(:symbolize_keys))
+      map = described_class.t(:map_array, hashes[:symbolize_keys])
 
       original = [
         { 'name' => 'Jane', 'title' => 'One' },
@@ -134,7 +136,7 @@ describe Transproc::ArrayTransformations do
 
   describe '.map_array!' do
     it 'updates array with the result of the function applied to each value' do
-      map = t(:map_array!, t(:symbolize_keys))
+      map = described_class.t(:map_array!, hashes[:symbolize_keys])
 
       input = [
         { 'name' => 'Jane', 'title' => 'One' },
@@ -154,7 +156,7 @@ describe Transproc::ArrayTransformations do
 
   describe '.wrap' do
     it 'returns a new array with wrapped hashes' do
-      wrap = t(:wrap, :task, [:title])
+      wrap = described_class.t(:wrap, :task, [:title])
 
       input = [{ name: 'Jane', title: 'One' }]
       output = [{ name: 'Jane', task: { title: 'One' } }]
@@ -164,10 +166,10 @@ describe Transproc::ArrayTransformations do
 
     it 'returns a array new with deeply wrapped hashes' do
       wrap =
-        t(
+        described_class.t(
           :map_array,
-          t(:nest, :user, [:name, :title]) +
-          t(:map_value, :user, t(:nest, :task, [:title]))
+          hashes[:nest, :user, [:name, :title]] +
+          hashes[:map_value, :user, hashes[:nest, :task, [:title]]]
         )
 
       input = [{ name: 'Jane', title: 'One' }]
@@ -177,7 +179,7 @@ describe Transproc::ArrayTransformations do
     end
 
     it 'adds data to the existing tuples' do
-      wrap = t(:wrap, :task, [:title])
+      wrap = described_class.t(:wrap, :task, [:title])
 
       input  = [{ name: 'Jane', task: { priority: 1 }, title: 'One' }]
       output = [{ name: 'Jane', task: { priority: 1, title: 'One' } }]
@@ -187,7 +189,7 @@ describe Transproc::ArrayTransformations do
   end
 
   describe '.group' do
-    subject(:group) { t(:group, :tasks, [:title]) }
+    subject(:group) { described_class.t(:group, :tasks, [:title]) }
 
     it 'returns a new array with grouped hashes' do
       input  = [{ name: 'Jane', title: 'One' }, { name: 'Jane', title: 'Two' }]
@@ -241,7 +243,7 @@ describe Transproc::ArrayTransformations do
   end
 
   describe '.ungroup' do
-    subject(:ungroup) { t(:ungroup, :tasks, [:title]) }
+    subject(:ungroup) { described_class.t(:ungroup, :tasks, [:title]) }
 
     it 'returns a new array with ungrouped hashes' do
       input = [{ name: 'Jane', tasks: [{ title: 'One' }, { title: 'Two' }] }]
@@ -325,12 +327,18 @@ describe Transproc::ArrayTransformations do
           { user: 'Jane', title: 'One', tags: [{ task: 'One', tag: 'red' }] },
           { user: 'Jane', title: 'Two', tags: [] }]
         },
-        { name: 'Joe', email: 'joe@doe.org', tasks: [
-          { user: 'Joe', title: 'Three', tags: [{ task: 'Three', tag: 'blue' }] }]
+        {
+          name: 'Joe', email: 'joe@doe.org', tasks: [
+            {
+              user: 'Joe', title: 'Three', tags: [
+                { task: 'Three', tag: 'blue' }
+              ]
+            }
+          ]
         }
       ]
 
-      combine = t(:combine, [
+      combine = described_class.t(:combine, [
         [:tasks, { name: :user }, [[:tags, title: :task]]]
       ])
 

--- a/spec/unit/class_transformations_spec.rb
+++ b/spec/unit/class_transformations_spec.rb
@@ -7,7 +7,7 @@ describe Transproc::ClassTransformations do
     end
 
     it 'returns a new object initialized with the given arguments' do
-      constructor_inject = t(:constructor_inject, klass)
+      constructor_inject = described_class.t(:constructor_inject, klass)
 
       input = ['Jane', 25]
       output = klass.new(*input)
@@ -33,7 +33,7 @@ describe Transproc::ClassTransformations do
     end
 
     it 'allocates a new object and sets instance variables from hash key/value pairs' do
-      set_ivars = t(:set_ivars, klass)
+      set_ivars = described_class.t(:set_ivars, klass)
 
       input = { name: 'Jane', age: 25 }
       output = klass.new(input)

--- a/spec/unit/coercions_spec.rb
+++ b/spec/unit/coercions_spec.rb
@@ -3,69 +3,69 @@ require 'spec_helper'
 describe Transproc::Coercions do
   describe '.to_string' do
     it 'turns integer into a string' do
-      expect(t(:to_string)[1]).to eql('1')
+      expect(described_class.t(:to_string)[1]).to eql('1')
     end
   end
 
   describe '.to_symbol' do
     it 'turns string into a symbol' do
-      expect(t(:to_symbol)['test']).to eql(:test)
+      expect(described_class.t(:to_symbol)['test']).to eql(:test)
     end
   end
 
   describe '.to_integer' do
     it 'turns string into an integer' do
-      expect(t(:to_integer)['1']).to eql(1)
+      expect(described_class.t(:to_integer)['1']).to eql(1)
     end
   end
 
   describe '.to_float' do
     it 'turns string into a float' do
-      expect(t(:to_float)['1']).to eql(1.0)
+      expect(described_class.t(:to_float)['1']).to eql(1.0)
     end
 
     it 'turns integer into a float' do
-      expect(t(:to_float)[1]).to eql(1.0)
+      expect(described_class.t(:to_float)[1]).to eql(1.0)
     end
   end
 
   describe '.to_decimal' do
     it 'turns string into a decimal' do
-      expect(t(:to_decimal)['1.251']).to eql(BigDecimal('1.251'))
+      expect(described_class.t(:to_decimal)['1.251']).to eql(BigDecimal('1.251'))
     end
 
     it 'turns float into a decimal' do
-      expect(t(:to_decimal)[1.251]).to eql(BigDecimal('1.251'))
+      expect(described_class.t(:to_decimal)[1.251]).to eql(BigDecimal('1.251'))
     end
 
     it 'turns integer into a decimal' do
-      expect(t(:to_decimal)[1]).to eql(BigDecimal('1.0'))
+      expect(described_class.t(:to_decimal)[1]).to eql(BigDecimal('1.0'))
     end
   end
 
   describe '.to_date' do
     it 'turns string into a date' do
       date = Date.new(1983, 11, 18)
-      expect(t(:to_date)['18th, November 1983']).to eql(date)
+      expect(described_class.t(:to_date)['18th, November 1983']).to eql(date)
     end
   end
 
   describe '.to_time' do
     it 'turns string into a time object' do
       time = Time.new(2012, 1, 23, 11, 7, 7)
-      expect(t(:to_time)['2012-01-23 11:07:07']).to eql(time)
+      expect(described_class.t(:to_time)['2012-01-23 11:07:07']).to eql(time)
     end
   end
 
   describe '.to_datetime' do
     it 'turns string into a date' do
       datetime = DateTime.new(2012, 1, 23, 11, 7, 7)
-      expect(t(:to_datetime)['2012-01-23 11:07:07']).to eql(datetime)
+      expect(described_class.t(:to_datetime)['2012-01-23 11:07:07']).to eql(datetime)
     end
   end
 
   describe '.to_boolean' do
-    subject(:coercer) { t(:to_boolean) }
+    subject(:coercer) { described_class.t(:to_boolean) }
 
     Transproc::Coercions::TRUE_VALUES.each do |value|
       it "turns #{value.inspect} to true" do
@@ -81,7 +81,7 @@ describe Transproc::Coercions do
   end
 
   describe '.to_tuples' do
-    subject(:to_tuples) { t(:to_tuples) }
+    subject(:to_tuples) { described_class.t(:to_tuples) }
 
     context 'non-array' do
       let(:input) { :foo }

--- a/spec/unit/composer_spec.rb
+++ b/spec/unit/composer_spec.rb
@@ -1,14 +1,23 @@
 require 'spec_helper'
 
 describe Transproc::Composer do
+  before do
+    module Foo
+      extend Transproc::Registry
+      import Transproc::ArrayTransformations
+      import Transproc::HashTransformations
+      import Transproc::Coercions
+    end
+  end
+
   subject(:object) do
     Class.new do
       include Transproc::Composer
 
       def fn
         compose do |fns|
-          fns << t(:map_array, t(:symbolize_keys)) <<
-            t(:map_array, t(:map_value, :age, t(:to_integer)))
+          fns << Foo[:map_array, Foo[:symbolize_keys]] <<
+            Foo[:map_array, Foo[:map_value, :age, Foo[:to_integer]]]
         end
       end
     end.new
@@ -17,4 +26,6 @@ describe Transproc::Composer do
   it 'allows composing functions' do
     expect(object.fn[[{ 'age' => '12' }]]).to eql([{ age: 12 }])
   end
+
+  after { Object.send :remove_const, :Foo }
 end

--- a/spec/unit/conditional_spec.rb
+++ b/spec/unit/conditional_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe Transproc::Conditional do
   describe '.guard' do
-    let(:fn) { t(:guard, ->(value) { value.is_a?(::String) }, t(:to_integer)) }
+    let(:fn) { described_class.t(:guard, condition, operation) }
+    let(:condition) { ->(value) { value.is_a?(::String) } }
+    let(:operation) { Transproc::Coercions.t(:to_integer) }
 
     context 'when predicate returns truthy value' do
       it 'applies the transformation and returns the result' do

--- a/spec/unit/function_spec.rb
+++ b/spec/unit/function_spec.rb
@@ -3,6 +3,22 @@ require 'spec_helper'
 describe Transproc::Function do
   let(:hashes) { Transproc::HashTransformations }
 
+  describe '#name' do
+    let(:block) { proc { |v| v } }
+
+    it 'returns the name of the module function' do
+      expect(hashes[:symbolize_keys].name).to eql :symbolize_keys
+    end
+
+    it 'returns the explicitly assigned name' do
+      expect(described_class.new(block, name: :identity).name).to eql :identity
+    end
+
+    it 'returns the unnamed closure' do
+      expect(described_class.new(block).name).to eql block
+    end
+  end
+
   describe '#>>' do
     it 'composes named functions' do
       f1 = hashes[:symbolize_keys]

--- a/spec/unit/function_spec.rb
+++ b/spec/unit/function_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 
-describe 'Transproc::Function' do
+describe Transproc::Function do
+  let(:hashes) { Transproc::HashTransformations }
+
   describe '#>>' do
     it 'composes named functions' do
-      f1 = t(:symbolize_keys)
-      f2 = t(:rename_keys, user_name: :name)
+      f1 = hashes[:symbolize_keys]
+      f2 = hashes[:rename_keys, user_name: :name]
 
       f3 = f1 >> f2
 
@@ -19,7 +21,7 @@ describe 'Transproc::Function' do
 
       expect(f3['user_name' => 'Jane']).to eql(name: 'Jane')
 
-      f4 = f3 >> t(:nest, :details, [:name])
+      f4 = f3 >> hashes[:nest, :details, [:name]]
 
       expect(f4.to_ast).to eql(
         [
@@ -54,7 +56,7 @@ describe 'Transproc::Function' do
     end
 
     it 'plays well with registered compositions' do
-      Transproc.register(:user_names, t(:symbolize_keys) + t(:rename_keys, user_name: :name))
+      Transproc.register(:user_names, hashes[:symbolize_keys] + hashes[:rename_keys, user_name: :name])
       f = t(:user_names)
 
       expect(f['user_name' => 'Jane']).to eql(name: 'Jane')

--- a/spec/unit/hash_transformations_spec.rb
+++ b/spec/unit/hash_transformations_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Transproc::HashTransformations do
   describe '.map_keys' do
     it 'returns a new hash with given proc applied to keys' do
-      map_keys = t(:map_keys, ->(key) { key.strip })
+      map_keys = described_class.t(:map_keys, ->(key) { key.strip })
 
       input = { ' foo ' => 'bar' }
       output = { 'foo' => 'bar' }
@@ -15,7 +15,7 @@ describe Transproc::HashTransformations do
 
   describe '.map_keys!' do
     it 'returns updated hash with given proc applied to keys' do
-      map_keys = t(:map_keys!, ->(key) { key.strip })
+      map_keys = described_class.t(:map_keys!, ->(key) { key.strip })
 
       input = { ' foo ' => 'bar' }
       output = { 'foo' => 'bar' }
@@ -27,7 +27,7 @@ describe Transproc::HashTransformations do
 
   describe '.symbolize_keys' do
     it 'returns a new hash with symbolized keys' do
-      symbolize_keys = t(:symbolize_keys)
+      symbolize_keys = described_class.t(:symbolize_keys)
 
       input = { 'foo' => 'bar' }
       output = { foo: 'bar' }
@@ -39,7 +39,7 @@ describe Transproc::HashTransformations do
 
   describe '.symbolize_keys!' do
     it 'returns updated hash with symbolized keys' do
-      symbolize_keys = t(:symbolize_keys!)
+      symbolize_keys = described_class.t(:symbolize_keys!)
 
       input = { 'foo' => 'bar' }
       output = { foo: 'bar' }
@@ -52,7 +52,7 @@ describe Transproc::HashTransformations do
 
   describe '.stringify_keys' do
     it 'returns a new hash with stringified keys' do
-      stringify_keys = t(:stringify_keys)
+      stringify_keys = described_class.t(:stringify_keys)
 
       input = { foo: 'bar' }
       output = { 'foo' => 'bar' }
@@ -64,7 +64,7 @@ describe Transproc::HashTransformations do
 
   describe '.stringify_keys!' do
     it 'returns a new hash with stringified keys' do
-      stringify_keys = t(:stringify_keys!)
+      stringify_keys = described_class.t(:stringify_keys!)
 
       input = { foo: 'bar' }
       output = { 'foo' => 'bar' }
@@ -76,7 +76,7 @@ describe Transproc::HashTransformations do
 
   describe '.map_values' do
     it 'returns a new hash with given proc applied to values' do
-      map_values = t(:map_values, ->(value) { value.strip })
+      map_values = described_class.t(:map_values, ->(value) { value.strip })
 
       input = { 'foo' => ' bar ' }
       output = { 'foo' => 'bar' }
@@ -88,7 +88,7 @@ describe Transproc::HashTransformations do
 
   describe '.map_values!' do
     it 'returns updated hash with given proc applied to values' do
-      map_values = t(:map_values!, ->(value) { value.strip })
+      map_values = described_class.t(:map_values!, ->(value) { value.strip })
 
       input = { 'foo' => ' bar ' }
       output = { 'foo' => 'bar' }
@@ -100,7 +100,7 @@ describe Transproc::HashTransformations do
 
   describe '.rename_keys' do
     it 'returns a new hash with applied functions' do
-      map = t(:rename_keys, 'foo' => :foo)
+      map = described_class.t(:rename_keys, 'foo' => :foo)
 
       input = { 'foo' => 'bar', :bar => 'baz' }
       output = { foo: 'bar', bar: 'baz' }
@@ -112,7 +112,7 @@ describe Transproc::HashTransformations do
 
   describe '.rename_keys!' do
     it 'returns updated hash with applied functions' do
-      map = t(:rename_keys!, 'foo' => :foo)
+      map = described_class.t(:rename_keys!, 'foo' => :foo)
 
       input = { 'foo' => 'bar', :bar => 'baz' }
       output = { foo: 'bar', bar: 'baz' }
@@ -125,7 +125,8 @@ describe Transproc::HashTransformations do
 
   describe '.map_value' do
     it 'applies function to value under specified key' do
-      transformation = t(:map_value, :user, t(:symbolize_keys))
+      transformation =
+        described_class.t(:map_value, :user, described_class.t(:symbolize_keys))
 
       input = { user: { 'name' => 'Jane' } }
       output = { user: { name: 'Jane' } }
@@ -137,7 +138,9 @@ describe Transproc::HashTransformations do
 
   describe '.map_value!' do
     it 'applies function to value under specified key' do
-      transformation = t(:map_value!, :user, t(:symbolize_keys))
+      transformation =
+        described_class
+        .t(:map_value!, :user, described_class.t(:symbolize_keys))
 
       input = { user: { 'name' => 'Jane' } }
       output = { user: { name: 'Jane' } }
@@ -150,7 +153,7 @@ describe Transproc::HashTransformations do
 
   describe '.nest' do
     it 'returns new hash with keys nested under a new key' do
-      nest = t(:nest, :baz, ['foo'])
+      nest = described_class.t(:nest, :baz, ['foo'])
 
       input = { 'foo' => 'bar' }
       output = { baz: { 'foo' => 'bar' } }
@@ -162,7 +165,7 @@ describe Transproc::HashTransformations do
 
   describe '.nest!' do
     it 'returns new hash with keys nested under a new key' do
-      nest = t(:nest!, :baz, ['one', 'two', 'not-here'])
+      nest = described_class.t(:nest!, :baz, ['one', 'two', 'not-here'])
 
       input = { 'foo' => 'bar', 'one' => nil, 'two' => false }
       output = { 'foo' => 'bar', baz: { 'one' => nil, 'two' => false } }
@@ -173,7 +176,7 @@ describe Transproc::HashTransformations do
     end
 
     it 'returns new hash with keys nested under the existing key' do
-      nest = t(:nest!, :baz, ['two'])
+      nest = described_class.t(:nest!, :baz, ['two'])
 
       input  = { 'foo' => 'bar', baz: { 'one' => nil }, 'two' => false }
       output = { 'foo' => 'bar', baz: { 'one' => nil, 'two' => false } }
@@ -184,7 +187,7 @@ describe Transproc::HashTransformations do
     end
 
     it 'rewrites the existing key if its value is not a hash' do
-      nest = t(:nest!, :baz, ['two'])
+      nest = described_class.t(:nest!, :baz, ['two'])
 
       input  = { 'foo' => 'bar', baz: 'one', 'two' => false }
       output = { 'foo' => 'bar', baz: { 'two' => false } }
@@ -195,7 +198,7 @@ describe Transproc::HashTransformations do
     end
 
     it 'returns new hash with an empty hash under a new key when nest-keys are missing' do
-      nest = t(:nest!, :baz, ['foo'])
+      nest = described_class.t(:nest!, :baz, ['foo'])
 
       input = { 'bar' => 'foo' }
       output = { 'bar' => 'foo', baz: {} }
@@ -208,7 +211,7 @@ describe Transproc::HashTransformations do
 
   describe '.unwrap!' do
     it 'returns updated hash with nested keys lifted to the root' do
-      unwrap = t(:unwrap!, 'wrapped', %w(one))
+      unwrap = described_class.t(:unwrap!, 'wrapped', %w(one))
 
       input = { 'foo' => 'bar', 'wrapped' => { 'one' => nil, 'two' => false } }
       output = { 'foo' => 'bar', 'one' => nil, 'wrapped' => { 'two' => false } }
@@ -219,7 +222,7 @@ describe Transproc::HashTransformations do
     end
 
     it 'lifts all keys if none are passed' do
-      unwrap = t(:unwrap!, 'wrapped')
+      unwrap = described_class.t(:unwrap!, 'wrapped')
 
       input = { 'wrapped' => { 'one' => nil, 'two' => false } }
       output = { 'one' => nil, 'two' => false }
@@ -230,7 +233,7 @@ describe Transproc::HashTransformations do
     end
 
     it 'ignores unknown keys' do
-      unwrap = t(:unwrap!, 'wrapped', %w(one two three))
+      unwrap = described_class.t(:unwrap!, 'wrapped', %w(one two three))
 
       input = { 'wrapped' => { 'one' => nil, 'two' => false } }
       output = { 'one' => nil, 'two' => false }
@@ -243,7 +246,7 @@ describe Transproc::HashTransformations do
 
   describe '.unwrap' do
     it 'returns new hash with nested keys lifted to the root' do
-      unwrap = t(:unwrap, 'wrapped')
+      unwrap = described_class.t(:unwrap, 'wrapped')
 
       input = {
         'foo' => 'bar',
@@ -260,8 +263,8 @@ describe Transproc::HashTransformations do
 
   describe 'nested transform' do
     it 'applies functions to nested hashes' do
-      symbolize_keys = t(:symbolize_keys)
-      map_user_key = t(:map_value, :user, symbolize_keys)
+      symbolize_keys = described_class.t(:symbolize_keys)
+      map_user_key = described_class.t(:map_value, :user, symbolize_keys)
 
       transformation = symbolize_keys >> map_user_key
 
@@ -274,8 +277,8 @@ describe Transproc::HashTransformations do
 
   describe 'combining transformations' do
     it 'applies functions to the hash' do
-      symbolize_keys = t(:symbolize_keys)
-      map = t(:rename_keys, user_name: :name, user_email: :email)
+      symbolize_keys = described_class.t(:symbolize_keys)
+      map = described_class.t(:rename_keys, user_name: :name, user_email: :email)
 
       transformation = symbolize_keys >> map
 
@@ -290,7 +293,7 @@ describe Transproc::HashTransformations do
 
   describe '.reject_keys!' do
     it 'returns an updated hash with rejected keys' do
-      reject_keys = t(:reject_keys, [:name, :age])
+      reject_keys = described_class.t(:reject_keys, [:name, :age])
 
       input = { name: 'Jane', email: 'jane@doe.org', age: 21 }
       output = { email: 'jane@doe.org' }
@@ -301,7 +304,7 @@ describe Transproc::HashTransformations do
 
   describe '.reject_keys' do
     it 'returns a new hash with rejected keys' do
-      reject_keys = t(:reject_keys, [:name, :age])
+      reject_keys = described_class.t(:reject_keys, [:name, :age])
 
       input = { name: 'Jane', email: 'jane@doe.org', age: 21 }
       output = { email: 'jane@doe.org' }
@@ -313,7 +316,7 @@ describe Transproc::HashTransformations do
 
   describe '.accept_keys!' do
     it 'returns an updated hash with accepted keys' do
-      accept_keys = t(:accept_keys, [:age])
+      accept_keys = described_class.t(:accept_keys, [:age])
 
       input = { name: 'Jane', email: 'jane@doe.org', age: 21 }
       output = { age: 21 }
@@ -324,7 +327,7 @@ describe Transproc::HashTransformations do
 
   describe '.reject_keys' do
     it 'returns a new hash with rejected keys' do
-      accept_keys = t(:accept_keys, [:age])
+      accept_keys = described_class.t(:accept_keys, [:age])
 
       input = { name: 'Jane', email: 'jane@doe.org', age: 21 }
       output = { age: 21 }
@@ -343,7 +346,7 @@ describe Transproc::HashTransformations do
     end
 
     it 'returns an updated hash with folded key' do
-      fold = t(:fold, :tasks, :title)
+      fold = described_class.t(:fold, :tasks, :title)
 
       output = { name: 'Jane', tasks: ['be nice', 'sleep well'] }
 
@@ -352,7 +355,7 @@ describe Transproc::HashTransformations do
     end
 
     it 'does not compact results' do
-      fold = t(:fold, :tasks, :priority)
+      fold = described_class.t(:fold, :tasks, :priority)
 
       output = { name: 'Jane', tasks: [1, nil] }
 
@@ -370,7 +373,7 @@ describe Transproc::HashTransformations do
     end
 
     it 'returns an updated hash with folded key' do
-      fold = t(:fold!, :tasks, :title)
+      fold = described_class.t(:fold!, :tasks, :title)
 
       output = { name: 'Jane', tasks: ['be nice', 'sleep well'] }
 
@@ -379,7 +382,7 @@ describe Transproc::HashTransformations do
     end
 
     it 'does not compact results' do
-      fold = t(:fold!, :tasks, :priority)
+      fold = described_class.t(:fold!, :tasks, :priority)
 
       output = { name: 'Jane', tasks: [1, nil] }
 
@@ -403,7 +406,7 @@ describe Transproc::HashTransformations do
     end
 
     it 'splits a tuple into array partially by given keys' do
-      split = t(:split, :tasks, [:priority])
+      split = described_class.t(:split, :tasks, [:priority])
 
       output = [
         {
@@ -424,7 +427,7 @@ describe Transproc::HashTransformations do
     end
 
     it 'splits a tuple into array fully by all subkeys' do
-      split = t(:split, :tasks, [:priority, :title])
+      split = described_class.t(:split, :tasks, [:priority, :title])
 
       output = [
         { name: 'Joe', title: 'sleep well', priority: 1   },
@@ -451,22 +454,22 @@ describe Transproc::HashTransformations do
         }
       ]
 
-      split = t(:split, :tasks, [])
+      split = described_class.t(:split, :tasks, [])
       expect(split[input]).to eql output
 
-      split = t(:split, :tasks, [:absent])
+      split = described_class.t(:split, :tasks, [:absent])
       expect(split[input]).to eql output
     end
 
     it 'returns an array of initial tuple when attribute is absent' do
-      split = t(:split, :absent, [:priority, :title])
+      split = described_class.t(:split, :absent, [:priority, :title])
       expect(split[input]).to eql [input]
     end
 
     it 'ignores empty array' do
       input = { name: 'Joe', tasks: [] }
 
-      split = t(:split, :tasks, [:title])
+      split = described_class.t(:split, :tasks, [:title])
 
       expect(split[input]).to eql [{ name: 'Joe' }]
     end

--- a/spec/unit/recursion_spec.rb
+++ b/spec/unit/recursion_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Transproc::Recursion do
+  let(:hashes) { Transproc::HashTransformations }
+
   describe '.recursion' do
     let(:original) do
       {
@@ -28,7 +30,7 @@ describe Transproc::Recursion do
 
     context 'when function is non-destructive' do
       let(:map) do
-        t(:recursion, -> enum {
+        described_class.t(:recursion, -> enum {
           enum.reject { |v| v == 'baz' }
         })
       end
@@ -41,7 +43,7 @@ describe Transproc::Recursion do
 
     context 'when function is destructive' do
       let(:map) do
-        t(:recursion, -> enum {
+        described_class.t(:recursion, -> enum {
           enum.reject! { |v| v == 'baz' }
         })
       end
@@ -87,7 +89,7 @@ describe Transproc::Recursion do
     end
 
     context 'when function is non-destructive' do
-      let(:map) { t(:array_recursion, proc(&:compact)) }
+      let(:map) { described_class.t(:array_recursion, proc(&:compact)) }
 
       it 'applies funtions to all items recursively' do
         expect(map[input]).to eql(output)
@@ -96,7 +98,7 @@ describe Transproc::Recursion do
     end
 
     context 'when function is destructive' do
-      let(:map) { t(:array_recursion, proc(&:compact!)) }
+      let(:map) { described_class.t(:array_recursion, proc(&:compact!)) }
 
       it 'applies funtions to all items recursively and destructively' do
         expect(map[input]).to eql(output)
@@ -135,7 +137,9 @@ describe Transproc::Recursion do
     end
 
     context 'when function is non-destructive' do
-      let(:map) { t(:hash_recursion, t(:symbolize_keys)) }
+      let(:map) do
+        described_class.t(:hash_recursion, hashes.t(:symbolize_keys))
+      end
 
       it 'applies funtions to all values recursively' do
         expect(map[input]).to eql(output)
@@ -144,7 +148,9 @@ describe Transproc::Recursion do
     end
 
     context 'when function is destructive' do
-      let(:map) { t(:hash_recursion, t(:symbolize_keys!)) }
+      let(:map) do
+        described_class.t(:hash_recursion, hashes.t(:symbolize_keys!))
+      end
 
       it 'applies funtions to all values recursively and destructively' do
         expect(map[input]).to eql(output)


### PR DESCRIPTION
1) Transformations should be defined as a singleton methods of registry module,
instead of instance methods:

```ruby
  module MyRegistry
    extend Transproc::Registry

    def self.prefix(value, prefix)
      # ...
    end
  end
```
All transformations have been redefined as singletone's.

2) Methods from another module can be imported using either `import` or
its alias `uses` singleton method call. You can import either all module methods,
or selected ones:
```ruby
  module MyRegistry
    extend Transproc::Registry

    import Inflecto
    import :map_array,   from: Transproc::ArrayTransformations
    import :rename_keys, from: Transproc::HashTrahsformations, as: :rename
  end
```
3) As before, method `[]` (and its alias `t`) converts singleton method to transproc.

4) Refactored specs and transformations to make them independent from global registry.

5) Because the function is defined locally from the module method, and
not necessary registered globally, it needs its own name to be carried
as an attribute.

The `Transproc::Registry.t` assings the name from its first argument:
```ruby
  HashTransformations[:rename_keys, foo: :bar].name # => :rename_keys
```
in other cases the anonymous source (closure) is used as a function name.
```ruby
  Transproc::Function.new(-> v { v }).name # => #<Proc ...>
```
There is also the possibility to set the name explicitly.
```ruby
  Transproc::Function.new(-> v { v }, name: :identity).name # => :identity
```