### PR TITLE
Fix rspec helpers

### DIFF
--- a/lib/transproc/rspec.rb
+++ b/lib/transproc/rspec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 # ==============================================================================
-# Examples for testing transproc __fn__s
+# Examples for testing transproc functions
 # ==============================================================================
 
 shared_context :call_transproc do


### PR DESCRIPTION
* Rename internal variables to prevent them from being clashed to user-defined.
* Support usage of `:transforming_data` example as standalone.

  Earlier it was used as a part of `:transforming_immutable_data` and
  `:mutating_input_data`.