### PR TITLE
add deep_merge function for HashTransformations

### DIFF
--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -429,6 +429,32 @@ module Transproc
       end
     end
 
+    # Merge a hash recursively
+    #
+    # @example
+    #
+    #   input = { 'foo' => 'bar', 'baz' => { 'one' => 1 } }
+    #   other = { 'foo' => 'buz', 'baz' => { :one => 'one', :two => 2 } }
+    #
+    #   t(:deep_merge)[input, other]
+    #   # => { 'foo' => "buz", :baz => { :one => 'one', 'one' => 1, :two => 2 } }
+    #
+    # @param [Hash]
+    # @param [Hash]
+    #
+    # @return [Hash]
+    #
+    # @api public
+    def self.deep_merge(hash, other)
+      Hash[hash].merge(other) do |key, original_value, new_value|
+        if original_value.respond_to?(:to_hash) && new_value.respond_to?(:to_hash)
+          deep_merge(Hash[original_value], Hash[new_value])
+        else
+          new_value
+        end
+      end
+    end
+
     # @deprecated Register methods globally
     (methods - Registry.instance_methods - Registry.methods)
       .each { |name| Transproc.register name, t(name) }

--- a/spec/unit/hash_transformations_spec.rb
+++ b/spec/unit/hash_transformations_spec.rb
@@ -509,4 +509,44 @@ describe Transproc::HashTransformations do
       expect(result[:hash]).to eql(one: 1)
     end
   end
+
+  describe '.deep_merge' do
+    let(:hash){
+      {
+        name: 'Jane',
+        email: 'jane@doe.org',
+        favorites:
+          {
+            food: 'stroopwafel'
+          }
+      }
+    }
+
+    let(:update){
+      {
+        email: 'jane@example.org',
+        favorites:
+          {
+            color: 'orange'
+          }
+      }
+    }
+
+    it 'recursively merges hash values' do
+      deep_merge = described_class.t(:deep_merge)
+      output = { name: 'Jane', email: 'jane@example.org', favorites: { food: 'stroopwafel', color: 'orange' } }
+
+      expect(deep_merge[hash, update]).to eql(output)
+    end
+
+    it 'does not alter the provided arguments' do
+      original_hash = hash.dup
+      original_update = update.dup
+
+      described_class.t(:deep_merge)[hash, update]
+
+      expect(hash).to eql(original_hash)
+      expect(update).to eql(original_update)
+    end
+  end
 end


### PR DESCRIPTION
* adds a :deep_merge option which will return a new hash where any values
which coerce into Hash will be recursively merged.
* it does _not_ merge hashes which may be contained in Array values.