### PR TITLE
Add `Transproc::Function#to_proc` instance method

### DIFF
--- a/lib/transproc/function.rb
+++ b/lib/transproc/function.rb
@@ -89,5 +89,13 @@ module Transproc
     def to_ast
       [name, args]
     end
+
+    # Converts a transproc to a simple proc
+    #
+    # @return [Proc]
+    #
+    def to_proc
+      fn.to_proc
+    end
   end
 end

--- a/spec/unit/function_spec.rb
+++ b/spec/unit/function_spec.rb
@@ -117,4 +117,45 @@ describe Transproc::Function do
       expect(left == right).to be(false)
     end
   end
+
+  describe '#to_proc' do
+    shared_examples :providing_a_proc do
+      let(:fn) { described_class.new(source) }
+      subject  { fn.to_proc }
+
+      it 'returns a proc' do
+        expect(subject).to be_instance_of Proc
+      end
+
+      it 'works fine' do
+        expect(subject.call :foo).to eql('foo')
+      end
+    end
+
+    context 'from a method' do
+      let(:source) do
+        mod = Module.new do
+          def self.get(x)
+            x.to_s
+          end
+        end
+        mod.method(:get)
+      end
+      it_behaves_like :providing_a_proc
+    end
+
+    context 'from a proc' do
+      let(:source) { -> value { value.to_s } }
+      it_behaves_like :providing_a_proc
+    end
+
+    context 'from a transproc' do
+      let(:source) { Transproc::Function.new -> value { value.to_s } }
+      it_behaves_like :providing_a_proc
+
+      it 'can be applied to collection' do
+        expect([:foo, :bar].map(&source)).to eql(%w(foo bar))
+      end
+    end
+  end
 end


### PR DESCRIPTION
The method converts function to proc.
This allows to apply `&` syntax to transprocs, for example when mapping a collection:

```ruby
  fn = Transproc::Function.new(-> v { v.to_s })
  [:foo, :bar].map(&fn) # convert fn to proc using `#to_proc`
  # => ['foo', 'bar']
```