### PR TITLE
Support symbolizing non-string values

### DIFF
--- a/lib/transproc/coercions.rb
+++ b/lib/transproc/coercions.rb
@@ -38,13 +38,13 @@ module Transproc
     #   Transproc(:to_symbol)['foo']
     #   # => :foo
     #
-    # @param [Object] value The input value
+    # @param [#to_s] value The input value
     #
     # @return [Symbol]
     #
     # @api public
     def self.to_symbol(value)
-      value.to_sym
+      value.to_s.to_sym
     end
 
     # Coerce value into a integer

--- a/spec/unit/coercions_spec.rb
+++ b/spec/unit/coercions_spec.rb
@@ -11,6 +11,10 @@ describe Transproc::Coercions do
     it 'turns string into a symbol' do
       expect(described_class.t(:to_symbol)['test']).to eql(:test)
     end
+
+    it 'turns non-string into a symbol' do
+      expect(described_class.t(:to_symbol)[1]).to eql(:'1')
+    end
   end
 
   describe '.to_integer' do

--- a/spec/unit/hash_transformations_spec.rb
+++ b/spec/unit/hash_transformations_spec.rb
@@ -30,11 +30,11 @@ describe Transproc::HashTransformations do
     it 'returns a new hash with symbolized keys' do
       symbolize_keys = described_class.t(:symbolize_keys)
 
-      input = { 'foo' => 'bar' }
-      output = { foo: 'bar' }
+      input = { 1 => 'bar' }
+      output = { :'1' => 'bar' }
 
       expect(symbolize_keys[input]).to eql(output)
-      expect(input).to eql('foo' => 'bar')
+      expect { symbolize_keys[input] }.not_to change { input }
     end
   end
 


### PR DESCRIPTION
Values should be stringifiable (respond to `to_s`, but not necessarily to `to_sym`):

```ruby
    fn = Transproc::Coersions[:to_symbol]
    fn[1] # => :'1'

    fn = Transproc::HashTransformations[:symbolize_keys]
    fn[1 => 1] # => { :'1' => 1 }
```