### PR TITLE
Support importing several methods at once

### DIFF
--- a/lib/transproc/registry.rb
+++ b/lib/transproc/registry.rb
@@ -54,46 +54,32 @@ module Transproc
     #
     # If the external module is a registry, looks for its imports too.
     #
-    # @example
-    #   module Foo
-    #     def self.foo(value)
-    #       value.upcase
-    #     end
+    # @overload import(source)
+    #   Loads all methods from the source object
     #
-    #     def self.bar(value)
-    #       value.downcase
-    #     end
-    #  end
+    #   @param [Object] source
     #
-    #  module Qux
-    #    def self.qux(value)
-    #      value.reverse
-    #    end
-    #  end
+    # @overload import(*names, **options)
+    #   Loads selected methods from the source object
     #
-    #  module Bar
-    #     extend Transproc::Registry
+    #   @param [Array<Symbol>] names
+    #   @param [Hash] options
+    #   @options options [Object] :from The source object
     #
-    #     import :foo, from: Foo, as: :baz
-    #     import :bar, from: Foo
-    #     import Qux
-    #  end
+    # @overload import(name, **options)
+    #   Loads selected methods from the source object
     #
-    #  Bar[:baz]['Qux'] # => 'QUX'
-    #  Bar[:bar]['Qux'] # => 'qux'
-    #  Bar[:qux]['Qux'] # => 'xuQ'
-    #
-    # @param [Module, #to_sym] name
-    # @option [Module] :from The module to take the method from
-    # @option [#to_sym] :as
-    #   The name of imported transproc inside the current module
+    #   @param [Symbol] name
+    #   @param [Hash] options
+    #   @options options [Object] :from The source object
+    #   @options options [Object] :as The new name for the transformation
     #
     # @return [itself] self
     #
     # @alias :import
     #
-    def import(source, options = nil)
-      @store = store.import(source, options)
+    def import(*args)
+      @store = store.import(*args)
       self
     end
     alias_method :uses, :import

--- a/spec/unit/registry_spec.rb
+++ b/spec/unit/registry_spec.rb
@@ -77,6 +77,17 @@ describe Transproc::Registry do
       end
     end
 
+    context 'a list of methods' do
+      before { bar.import :prefix, from: foo }
+      before { bar.import :prefix, from: foo, as: :affix }
+      before { baz.import :prefix, :affix, from: bar }
+
+      it 'registers a transproc' do
+        expect(baz[:prefix, 'bar']['baz']).to eql 'bar_baz'
+        expect(baz[:affix, 'bar']['baz']).to eql 'bar_baz'
+      end
+    end
+
     context 'a renamed method' do
       before { bar.import :prefix, from: foo, as: :affix }
 

--- a/spec/unit/store_spec.rb
+++ b/spec/unit/store_spec.rb
@@ -38,7 +38,7 @@ describe Transproc::Store do
     end
   end # describe #fetch
 
-  describe '#import' do
+  describe '#import', :focus do
     before do
       module Bar
         def self.bar
@@ -88,6 +88,20 @@ describe Transproc::Store do
       it_behaves_like :importing_method do
         let(:key)   { :qux }
         let(:value) { :qux }
+      end
+    end
+
+    context 'named methods' do
+      subject { store.import 'qux', 'bar', from: Qux }
+
+      it_behaves_like :importing_method do
+        let(:key)   { :qux }
+        let(:value) { :qux }
+      end
+
+      it_behaves_like :importing_method do
+        let(:key)   { :bar }
+        let(:value) { :bar }
       end
     end
 


### PR DESCRIPTION
```ruby
  module Functions
    extend Transproc::Registry

    import :foo, :bar, :baz, from: Foo
  end
```