### PR TITLE
Remove `MalformedInputError`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,16 @@ gemspec
 
 group :test do
   gem 'equalizer'
-  gem 'anima'
   gem 'codeclimate-test-reporter', require: nil
 
-  platform :mri do
-    gem 'mutant', github: 'mbj/mutant', branch: 'master'
-    gem 'mutant-rspec'
+  if RUBY_VERSION >= '2.1'
+    gem 'anima'
+    platform :mri do
+      gem 'mutant', github: 'mbj/mutant', branch: 'master'
+      gem 'mutant-rspec'
+    end
+  else
+    gem 'anima', '~> 0.2.0'
   end
 end
 

--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -40,7 +40,7 @@ module Transproc
   #
   # @api private
   def self.[](name, *args)
-    fn = functions.fetch(name) { raise FunctionNotFoundError.new(name) }
+    fn = functions.fetch(name) { raise(FunctionNotFoundError, name) }
 
     if args.any?
       fn.with(*args)

--- a/lib/transproc/composite.rb
+++ b/lib/transproc/composite.rb
@@ -27,7 +27,7 @@ module Transproc
     #
     # @api public
     def call(value)
-      right.(left.(value))
+      right.call(left.call(value))
     end
     alias_method :[], :call
 

--- a/lib/transproc/error.rb
+++ b/lib/transproc/error.rb
@@ -8,16 +8,4 @@ module Transproc
       super "No globally registered function for #{function}"
     end
   end
-
-  class MalformedInputError < Error
-    attr_reader :function, :value, :original_error
-
-    def initialize(function, value, error)
-      @function = function
-      @value = value
-      @original_error = error
-      super "Failed to call_function #{function} with #{value.inspect} - #{error}"
-      set_backtrace(error.backtrace)
-    end
-  end
 end

--- a/lib/transproc/function.rb
+++ b/lib/transproc/function.rb
@@ -45,8 +45,6 @@ module Transproc
     # @api public
     def call(*value)
       fn.(*value, *args)
-    rescue => e
-      raise MalformedInputError.new(@name, value, e)
     end
     alias_method :[], :call
 

--- a/lib/transproc/function.rb
+++ b/lib/transproc/function.rb
@@ -44,7 +44,7 @@ module Transproc
     #
     # @api public
     def call(*value)
-      fn.(*value, *args)
+      fn.call(*value, *args)
     end
     alias_method :[], :call
 

--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -446,8 +446,9 @@ module Transproc
     #
     # @api public
     def self.deep_merge(hash, other)
-      Hash[hash].merge(other) do |key, original_value, new_value|
-        if original_value.respond_to?(:to_hash) && new_value.respond_to?(:to_hash)
+      Hash[hash].merge(other) do |_, original_value, new_value|
+        if original_value.respond_to?(:to_hash) &&
+           new_value.respond_to?(:to_hash)
           deep_merge(Hash[original_value], Hash[new_value])
         else
           new_value

--- a/lib/transproc/recursion.rb
+++ b/lib/transproc/recursion.rb
@@ -10,8 +10,8 @@ module Transproc
   #
   #   fn = t(:hash_recursion, t(:symbolize_keys))
   #
-  #   fn["name" => "Jane", "address" => { "street" => "Street 1", "zipcode" => "123" }]
-  #   # => {:name=>"Jane", :address=>{:street=>"Street 1", :zipcode=>"123"}}
+  #   fn["name" => "Jane", "address" => { "street" => "Street 1" }]
+  #   # => {:name=>"Jane", :address=>{:street=>"Street 1"}}
   #
   # @api public
   module Recursion
@@ -36,7 +36,14 @@ module Transproc
     #       ]
     #     }
     #   ]
-    #   => {:id=>1, :name=>"Jane", :tasks=>[{:id=>1, :description=>"Write some code"}, {:id=>2, :description=>"Write some more code"}]}
+    #   => {
+    #        :id=>1,
+    #        :name=>"Jane",
+    #        :tasks=>[
+    #          {:id=>1, :description=>"Write some code"},
+    #          {:id=>2, :description=>"Write some more code"}
+    #        ]
+    #      }
     #
     # @param [Enumerable]
     #

--- a/lib/transproc/rspec.rb
+++ b/lib/transproc/rspec.rb
@@ -5,8 +5,15 @@
 # ==============================================================================
 
 shared_context :call_transproc do
-  let!(:__initial__) { input.dup rescue input      }
-  let!(:__fn__)      { described_class[*arguments] }
+  let!(:__fn__) { described_class[*arguments] }
+  let!(:__initial__) do
+    begin
+      input.dup
+    rescue
+      input
+    end
+  end
+
   subject { __fn__[input] }
 end
 
@@ -14,7 +21,7 @@ shared_examples :transforming_data do
   include_context :call_transproc
 
   it '[returns the expected output]' do
-    expect(subject).to eql(output), <<-REPORT.gsub(/.+\|/, "")
+    expect(subject).to eql(output), <<-REPORT.gsub(%r{.+\|}, '')
       |
       |fn = #{described_class}#{Array[*arguments]}
       |
@@ -33,7 +40,7 @@ shared_examples :transforming_immutable_data do
 
   it '[keeps input unchanged]' do
     expect { subject }
-      .not_to change { input }, <<-REPORT.gsub(/.+\|/, "")
+      .not_to change { input }, <<-REPORT.gsub(%r{.+\|}, '')
         |
         |fn = #{described_class}#{Array[*arguments]}
         |
@@ -51,7 +58,7 @@ shared_examples :mutating_input_data do
   it '[changes input]' do
     expect { subject }
       .to change { input }
-      .to(output), <<-REPORT.gsub(/.+\|/, "")
+      .to(output), <<-REPORT.gsub(%r{.+\|}, '')
         |
         |fn = #{described_class}#{Array[*arguments]}
         |

--- a/lib/transproc/support/deprecations.rb
+++ b/lib/transproc/support/deprecations.rb
@@ -1,10 +1,10 @@
 module Transproc
   module Deprecations
     def self.announce(name, msg)
-      warn <<-MSG.gsub(/^\s+/, '')
+      warn <<-MSG.gsub(%r{^\s+}, '')
         #{name} is deprecated and will be removed in 1.0.0.
         #{msg}
-        #{caller.detect { |l| !l.include?('lib/transproc')}}
+        #{caller.detect { |l| !l.include?('lib/transproc') } }
       MSG
     end
   end

--- a/spec/unit/function_not_found_error_spec.rb
+++ b/spec/unit/function_not_found_error_spec.rb
@@ -4,8 +4,8 @@ describe Transproc::FunctionNotFoundError do
   it 'complains that the function not registered globally' do
     expect { Transproc(:foo) }.to raise_error do |error|
       expect(error).to be_kind_of described_class
-      expect(error.message["foo"]).not_to be_nil
-      expect(error.message["global"]).not_to be_nil
+      expect(error.message['foo']).not_to be_nil
+      expect(error.message['global']).not_to be_nil
     end
   end
 
@@ -14,7 +14,7 @@ describe Transproc::FunctionNotFoundError do
 
     expect { Foo[:foo] }.to raise_error do |error|
       expect(error).to be_kind_of described_class
-      expect(error.message["function Foo[:foo]"]).not_to be_nil
+      expect(error.message['function Foo[:foo]']).not_to be_nil
     end
   end
 end

--- a/spec/unit/hash_transformations_spec.rb
+++ b/spec/unit/hash_transformations_spec.rb
@@ -31,7 +31,7 @@ describe Transproc::HashTransformations do
       symbolize_keys = described_class.t(:symbolize_keys)
 
       input = { 1 => 'bar' }
-      output = { :'1' => 'bar' }
+      output = { '1'.to_sym => 'bar' }
 
       expect(symbolize_keys[input]).to eql(output)
       expect { symbolize_keys[input] }.not_to change { input }
@@ -46,7 +46,7 @@ describe Transproc::HashTransformations do
       output = { foo: 'bar', baz: [{ one: 1 }, 'two'] }
 
       expect(symbolize_keys[input]).to eql(output)
-      expect(input).to eql({ 'foo' => 'bar', 'baz' => [{ 'one' => 1 }, 'two'] })
+      expect(input).to eql('foo' => 'bar', 'baz' => [{ 'one' => 1 }, 'two'])
     end
   end
 
@@ -178,7 +178,7 @@ describe Transproc::HashTransformations do
 
   describe '.nest!' do
     it 'returns new hash with keys nested under a new key' do
-      nest = described_class.t(:nest!, :baz, ['one', 'two', 'not-here'])
+      nest = described_class.t(:nest!, :baz, %w(one two not-here))
 
       input = { 'foo' => 'bar', 'one' => nil, 'two' => false }
       output = { 'foo' => 'bar', baz: { 'one' => nil, 'two' => false } }
@@ -291,7 +291,7 @@ describe Transproc::HashTransformations do
   describe 'combining transformations' do
     it 'applies functions to the hash' do
       symbolize_keys = described_class.t(:symbolize_keys)
-      map = described_class.t(:rename_keys, user_name: :name, user_email: :email)
+      map = described_class.t :rename_keys, user_name: :name, user_email: :email
 
       transformation = symbolize_keys >> map
 
@@ -477,8 +477,8 @@ describe Transproc::HashTransformations do
       evaluate = described_class.t(:eval_values, 1)
 
       input = {
-        one: 1, two: -> i { i+1 },
-        three: -> i { i+2 }, four: 4,
+        one: 1, two: -> i { i + 1 },
+        three: -> i { i + 2 }, four: 4,
         more: [{ one: -> i { i }, two: 2 }]
       }
 
@@ -495,8 +495,8 @@ describe Transproc::HashTransformations do
       evaluate = described_class.t(:eval_values, 1, [:one, :two])
 
       input = {
-        one: 1, two: -> i { i+1 },
-        three: -> i { i+2 }, four: 4,
+        one: 1, two: -> i { i + 1 },
+        three: -> i { i + 2 }, four: 4,
         array: [{ one: -> i { i }, two: 2 }],
         hash: { one: -> i { i } }
       }
@@ -511,7 +511,7 @@ describe Transproc::HashTransformations do
   end
 
   describe '.deep_merge' do
-    let(:hash){
+    let(:hash) {
       {
         name: 'Jane',
         email: 'jane@doe.org',
@@ -522,7 +522,7 @@ describe Transproc::HashTransformations do
       }
     }
 
-    let(:update){
+    let(:update) {
       {
         email: 'jane@example.org',
         favorites:
@@ -534,7 +534,11 @@ describe Transproc::HashTransformations do
 
     it 'recursively merges hash values' do
       deep_merge = described_class.t(:deep_merge)
-      output = { name: 'Jane', email: 'jane@example.org', favorites: { food: 'stroopwafel', color: 'orange' } }
+      output = {
+        name: 'Jane',
+        email: 'jane@example.org',
+        favorites: { food: 'stroopwafel', color: 'orange' }
+      }
 
       expect(deep_merge[hash, update]).to eql(output)
     end

--- a/spec/unit/recursion_spec.rb
+++ b/spec/unit/recursion_spec.rb
@@ -9,7 +9,7 @@ describe Transproc::Recursion do
         'foo' => 'bar',
         'bar' => {
           'foo' => 'bar',
-          'bar' => ['foo', 'bar', 'baz'],
+          'bar' => %w(foo bar baz),
           'baz' => 'foo'
         },
         'baz' => 'bar'
@@ -23,7 +23,7 @@ describe Transproc::Recursion do
         'foo' => 'bar',
         'bar' => {
           'foo' => 'bar',
-          'bar' => ['foo', 'bar'],
+          'bar' => %w(foo bar)
         }
       }
     end

--- a/spec/unit/transproc_spec.rb
+++ b/spec/unit/transproc_spec.rb
@@ -57,20 +57,4 @@ describe Transproc do
       expect(fn.args).to include(Transproc(:to_string))
     end
   end
-
-  describe 'handling malformed input' do
-    it 'raises a Transproc::MalformedInputError' do
-      expect {
-        Transproc(:to_integer)[{}]
-      }.to raise_error(Transproc::MalformedInputError)
-
-      begin
-        Transproc(:to_integer)[{}]
-      rescue Transproc::MalformedInputError => e
-        expect(e.message).to include('to_integer')
-        expect(e.message).to include("undefined method `to_i'")
-        expect(e.backtrace).to eql(e.original_error.backtrace)
-      end
-    end
-  end
 end


### PR DESCRIPTION
The exceptions occured inside transformations are no longer catched and
re-risen in form of `Transproc::MalformedInputError`.

This allows transformations to raise their own exceptions as side effects.
```ruby
    extend Transproc::Registry

    def self.check_type(value, type)
      return value if value.is_a? type
      fail ArgumentError "#{value.inspect} is expected to be kind of #{type}"
    end
```