### PR TITLE
Prevent rename_keys from overwriting data

### DIFF
--- a/lib/transproc/hash.rb
+++ b/lib/transproc/hash.rb
@@ -171,7 +171,7 @@ module Transproc
     #
     # @api public
     def self.rename_keys!(hash, mapping)
-      mapping.each { |k, v| hash[v] = hash.delete(k) }
+      mapping.each { |k, v| hash[v] = hash.delete(k) if hash.has_key?(k) }
       hash
     end
 

--- a/spec/unit/hash_transformations_spec.rb
+++ b/spec/unit/hash_transformations_spec.rb
@@ -121,6 +121,16 @@ describe Transproc::HashTransformations do
       expect(map[input]).to eql(output)
       expect(input).to eql('foo' => 'bar', :bar => 'baz')
     end
+
+    it "only renames keys and never creates new ones" do
+      map = described_class.t(:rename_keys, 'foo' => :foo, 'bar' => :bar)
+
+      input = { 'bar' => 'baz' }
+      output = { bar: 'baz' }
+
+      expect(map[input]).to eql(output)
+      expect(input).to eql('bar' => 'baz')
+    end
   end
 
   describe '.rename_keys!' do


### PR DESCRIPTION
Fixes an issue where calling `rename_keys` could cause data in a hash to be deleted (as discussed in #64).

`rename_keys` accepts a hash in which each key represents a key in the value has that will be renamed *from*, and each value represents a key that will be renamed *to*.

Data was deleted in the case that the "to" key already existed, but the "from" key did not. This is because `delete(from)` was called on the value hash; Ruby will return `nil` if `Hash#delete` is called with a nonexistent key, and so `hash[to]` was always set to `nil` in these cases.

`rename_keys` will now only set the "to" element in the hash if the "from" key exists, preventing this issue from happening.