### PR TITLE
Rename local variable fun to func for Rubinius compatibility

### DIFF
--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -78,10 +78,10 @@ def Transproc(fn, *args)
   case fn
   when Proc then Transproc::Function.new(fn, args: args)
   when Symbol
-    fun = Transproc[fn, *args]
-    case fun
-    when Transproc::Function, Transproc::Composite then fun
-    else Transproc::Function.new(fun, args: args)
+    func = Transproc[fn, *args]
+    case func
+    when Transproc::Function, Transproc::Composite then func
+    else Transproc::Function.new(func, args: args)
     end
   end
 end


### PR DESCRIPTION
`fun` apparently became a reserver word in new Rubinius version (see [here](https://medium.com/@rubinius/rubinius-takes-the-fun-out-of-ruby-21db64ce87a6#.6c0m6v5yk) for more info) and it prevents transproc to work with it. Since `fun`is only a local variable, not any part of public API, renaming it does not do any harm and make transproc work with those new versions.

Now, I don't know if transproc cares a lot about compatibility with Rubinius (which sometimes makes some weird changes IMO), but I think that the amount of changes needed to make it work is so small that it's worth the effort.

The error in rbx 3.59 is:

```
A syntax error has occurred:
    syntax error, unexpected '=': /home/katafrakt/dev/github/transproc/lib/transproc.rb:81:9

Code:
    fun = Transproc[fn, *args]
```
