### PR TITLE
Improved Transformer DSL

### DIFF
--- a/lib/transproc.rb
+++ b/lib/transproc.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'transproc/version'
+require 'transproc/constants'
 require 'transproc/function'
 require 'transproc/functions'
 require 'transproc/composer'
@@ -9,10 +10,6 @@ require 'transproc/store'
 require 'transproc/registry'
 require 'transproc/transformer'
 require 'transproc/support/deprecations'
-
-module Transproc
-  Undefined = Object.new.freeze
-end
 
 require 'transproc/array'
 require 'transproc/hash'

--- a/lib/transproc/compiler.rb
+++ b/lib/transproc/compiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Transproc
   # @api private
   class Compiler

--- a/lib/transproc/compiler.rb
+++ b/lib/transproc/compiler.rb
@@ -1,0 +1,43 @@
+module Transproc
+  # @api private
+  class Compiler
+    InvalidFunctionNameError = Class.new(StandardError)
+
+    attr_reader :registry, :transformer
+
+    def initialize(registry, transformer = nil)
+      @registry = registry
+      @transformer = transformer
+    end
+
+    def call(ast)
+      ast.map(&method(:visit)).reduce(:>>)
+    end
+
+    def visit(node)
+      id, *rest = node
+      public_send(:"visit_#{id}", *rest)
+    end
+
+    def visit_fn(node)
+      name, rest = node
+      args = rest.map { |arg| visit(arg) }
+
+      if registry.contain?(name)
+        registry[name, *args]
+      elsif transformer.respond_to?(name)
+        Function.new(transformer.method(name), name: name, args: args)
+      else
+        raise InvalidFunctionNameError, "function name +#{name}+ is not valid"
+      end
+    end
+
+    def visit_arg(arg)
+      arg
+    end
+
+    def visit_t(node)
+      call(node)
+    end
+  end
+end

--- a/lib/transproc/constants.rb
+++ b/lib/transproc/constants.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Transproc
   Undefined = Object.new.freeze
 end

--- a/lib/transproc/constants.rb
+++ b/lib/transproc/constants.rb
@@ -1,0 +1,3 @@
+module Transproc
+  Undefined = Object.new.freeze
+end

--- a/lib/transproc/transformer.rb
+++ b/lib/transproc/transformer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'transproc/transformer/class_interface'
+require 'transproc/transformer/deprecated/class_interface'
 
 module Transproc
   # Transfomer class for defining transprocs with a class DSL.
@@ -47,6 +48,7 @@ module Transproc
   # @api public
   class Transformer
     extend ClassInterface
+    extend Deprecated::ClassInterface
 
     attr_reader :transproc
 

--- a/lib/transproc/transformer.rb
+++ b/lib/transproc/transformer.rb
@@ -48,6 +48,8 @@ module Transproc
   class Transformer
     extend ClassInterface
 
+    attr_reader :transproc
+
     # Execute the transformation pipeline with the given input.
     #
     # @example
@@ -65,7 +67,7 @@ module Transproc
     #
     # @api public
     def call(input)
-      self.class.transproc.call(input)
+      transproc.call(input)
     end
   end
 end

--- a/lib/transproc/transformer/class_interface.rb
+++ b/lib/transproc/transformer/class_interface.rb
@@ -1,53 +1,9 @@
 # frozen_string_literal: true
 
-require 'transproc/compiler'
+require 'transproc/transformer/dsl'
 
 module Transproc
   class Transformer
-    # @api public
-    class DSL
-      # @api private
-      attr_reader :container
-
-      # @api private
-      attr_reader :ast
-
-      # @api private
-      def initialize(container, ast: [], &block)
-        @container = container
-        @ast = ast
-        instance_eval(&block) if block
-      end
-
-      # @api private
-      def dup
-        self.class.new(container, ast: ast.dup)
-      end
-
-      # @api private
-      def call(transformer)
-        Compiler.new(container, transformer).(ast)
-      end
-
-      private
-
-      # @api private
-      def node(&block)
-        [:t, self.class.new(container, &block).ast]
-      end
-
-      # @api private
-      def respond_to_missing?(method, _include_private = false)
-        super || container.contain?(method)
-      end
-
-      # @api private
-      def method_missing(meth, *args, &block)
-        arg_nodes = *args.map { |a| [:arg, a] }
-        ast << [:fn, (block ? [meth, [*arg_nodes, node(&block)]] : [meth, arg_nodes])]
-      end
-    end
-
     # @api public
     module ClassInterface
       # @api private

--- a/lib/transproc/transformer/class_interface.rb
+++ b/lib/transproc/transformer/class_interface.rb
@@ -74,9 +74,7 @@ module Transproc
       # @api public
       def new
         super.tap do |transformer|
-          if dsl
-            transformer.instance_variable_set('@transproc', dsl.(transformer))
-          end
+          transformer.instance_variable_set('@transproc', dsl.(transformer)) if dsl
         end
       end
 

--- a/lib/transproc/transformer/deprecated/class_interface.rb
+++ b/lib/transproc/transformer/deprecated/class_interface.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Transproc
+  class Transformer
+    module Deprecated
+      # @api public
+      module ClassInterface
+        # @api public
+        def new
+          transformer = super
+          transformer.instance_variable_set('@transproc', transproc) if transformations.any?
+          transformer
+        end
+
+        # @api private
+        def inherited(subclass)
+          super
+
+          if transformations.any?
+            subclass.instance_variable_set('@transformations', transformations.dup)
+          end
+        end
+
+        # Define an anonymous transproc derived from given Transformer
+        # Evaluates block with transformations and returns initialized transproc.
+        # Does not mutate original Transformer
+        #
+        # @example
+        #
+        #   class MyTransformer < Transproc::Transformer[MyContainer]
+        #   end
+        #
+        #   transproc = MyTransformer.define do
+        #     map_values t(:to_string)
+        #   end
+        #   transproc.call(a: 1, b: 2)
+        #   # => {a: '1', b: '2'}
+        #
+        # @yield Block allowing to define transformations. The same as class level DSL
+        #
+        # @return [Function] Composed transproc
+        #
+        # @api public
+        def define(&block)
+          return transproc unless block_given?
+
+          Class.new(Transformer[container]).tap { |klass| klass.instance_eval(&block) }.transproc
+        end
+        alias build define
+
+        # @api private
+        def method_missing(method, *args, &block)
+          super unless container.contain?(method)
+          func = block ? t(method, *args, define(&block)) : t(method, *args)
+          transformations << func
+          func
+        end
+
+        # @api private
+        def respond_to_missing?(method, _include_private = false)
+          super || container.contain?(method)
+        end
+
+        # @api private
+        def transproc
+          transformations.reduce(:>>)
+        end
+
+        private
+
+        # An array containing the transformation pipeline
+        #
+        # @api private
+        def transformations
+          @transformations ||= []
+        end
+      end
+    end
+  end
+end

--- a/lib/transproc/transformer/dsl.rb
+++ b/lib/transproc/transformer/dsl.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'transproc/compiler'
+
+module Transproc
+  class Transformer
+    # @api public
+    class DSL
+      # @api private
+      attr_reader :container
+
+      # @api private
+      attr_reader :ast
+
+      # @api private
+      def initialize(container, ast: [], &block)
+        @container = container
+        @ast = ast
+        instance_eval(&block) if block
+      end
+
+      # @api private
+      def dup
+        self.class.new(container, ast: ast.dup)
+      end
+
+      # @api private
+      def call(transformer)
+        Compiler.new(container, transformer).(ast)
+      end
+
+      private
+
+      # @api private
+      def node(&block)
+        [:t, self.class.new(container, &block).ast]
+      end
+
+      # @api private
+      def respond_to_missing?(method, _include_private = false)
+        super || container.contain?(method)
+      end
+
+      # @api private
+      def method_missing(meth, *args, &block)
+        arg_nodes = *args.map { |a| [:arg, a] }
+        ast << [:fn, (block ? [meth, [*arg_nodes, node(&block)]] : [meth, arg_nodes])]
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,12 +13,11 @@ if RUBY_ENGINE == 'ruby' && ENV['COVERAGE'] == 'true'
   end
 end
 
-require 'transproc/all'
-
 begin
   require 'byebug'
-rescue LoadError
-end
+rescue LoadError;end
+
+require 'transproc/all'
 
 root = Pathname(__FILE__).dirname
 Dir[root.join('support/*.rb').to_s].each { |f| require f }

--- a/spec/unit/transformer/dsl_spec.rb
+++ b/spec/unit/transformer/dsl_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Transproc::Transformer do
+  let(:container) { Module.new { extend Transproc::Registry } }
+  let(:klass) { Transproc::Transformer[container] }
+  let(:transformer) { klass.new }
+
+  context 'when invalid method is used' do
+    it 'raises an error on initialization' do
+      klass.define! do
+        not_valid
+      end
+
+      expect { klass.new }.to raise_error(Transproc::Compiler::InvalidFunctionNameError, /not_valid/)
+    end
+  end
+end

--- a/spec/unit/transformer/instance_methods_spec.rb
+++ b/spec/unit/transformer/instance_methods_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe Transproc::Transformer, 'instance methods' do
   subject(:transformer) do
     Class.new(Transproc::Transformer[registry]) do
-      map_array(&:capitalize)
+      define! do
+        map_array(&:capitalize)
+      end
 
       def capitalize(input)
         input.upcase

--- a/spec/unit/transformer/instance_methods_spec.rb
+++ b/spec/unit/transformer/instance_methods_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Transproc::Transformer, 'instance methods' do
+  subject(:transformer) do
+    Class.new(Transproc::Transformer[registry]) do
+      map_array(&:capitalize)
+
+      def capitalize(input)
+        input.upcase
+      end
+    end.new
+  end
+
+  let(:registry) do
+    Module.new do
+      extend Transproc::Registry
+
+      import Transproc::ArrayTransformations
+    end
+  end
+
+  it 'registers a new transformation function' do
+    expect(transformer.call(%w[foo bar])).to eql(%w[FOO BAR])
+  end
+end

--- a/spec/unit/transformer_spec.rb
+++ b/spec/unit/transformer_spec.rb
@@ -229,6 +229,28 @@ describe Transproc::Transformer do
     end
   end
 
+  describe '.method_missing' do
+    it 'responds to missing when there is a corresponding function' do
+      container.import Transproc::HashTransformations
+
+      expect(klass.method(:map_values)).to be_a(Method)
+    end
+
+    it 'responds to missing when there is a corresponding instance method' do
+      pending
+
+      klass.define_method(:map_values) {}
+
+      expect(klass.method(:map_values)).to be_a(Method)
+    end
+
+    it 'raises when there is no corresponding function or instance method' do
+      pending
+
+      expect { klass.not_here }.to raise_error(NoMethodError, /not_here/)
+    end
+  end
+
   describe '#call' do
     let(:container) do
       Module.new do

--- a/spec/unit/transformer_spec.rb
+++ b/spec/unit/transformer_spec.rb
@@ -33,65 +33,6 @@ describe Transproc::Transformer do
     end
   end
 
-  describe '.method_missing' do
-    context 'when the method name matches a registered function' do
-      it 'registers a transformation without args' do
-        container.import(Transproc::Coercions)
-
-        func = klass.t(:to_string)
-
-        result = klass.to_string
-
-        expect(result).to eql(func)
-      end
-
-      it 'registers a transformation with args' do
-        container.import(Transproc::HashTransformations)
-
-        func = klass.t(:rename_keys, id: :user_id)
-
-        result = klass.rename_keys(id: :user_id)
-
-        expect(result).to eql(func)
-      end
-
-      it 'registers a transformation with a block' do
-        container.import(Transproc::ArrayTransformations)
-        container.import(Transproc::HashTransformations)
-
-        func = klass.t(:map_array, klass.t(:rename_keys, id: :user_id))
-
-        result = klass.map_array { rename_keys(id: :user_id) }
-
-        expect(result).to eql(func)
-      end
-
-      it 'registers a transformation with args and a block' do
-        container.import(Transproc::HashTransformations)
-
-        func = klass.t(:map_value, :user, klass.t(:rename_keys, id: :user_id))
-
-        result = klass.map_value(:user) { rename_keys(id: :user_id) }
-
-        expect(result).to eql(func)
-      end
-
-      it 'works with #method' do
-        container.import(Transproc::Coercions)
-
-        func = klass.t(:to_string)
-
-        expect(klass.method(:to_string).()).to eql(func)
-      end
-    end
-
-    context 'when the method name does not match any registered function' do
-      it 'raises NoMethodError' do
-        expect { klass.not_here }.to raise_error(NoMethodError, /not_here/)
-      end
-    end
-  end
-
   describe 'inheritance' do
     let(:container) do
       Module.new do
@@ -147,7 +88,7 @@ describe Transproc::Transformer do
     end
 
     it 'does not inherit transproc' do
-      expect(klass[container].transproc).to be_nil
+      expect(klass[container].new.transproc).to be_nil
     end
 
     context 'with predefined transformer' do
@@ -161,7 +102,7 @@ describe Transproc::Transformer do
       end
 
       it "inherits parent's transproc" do
-        expect(klass[container].transproc).to eql(klass.transproc)
+        expect(klass[container].new.transproc).to eql(klass.new.transproc)
       end
     end
   end
@@ -202,7 +143,7 @@ describe Transproc::Transformer do
         map_value(:attr, :to_sym.to_proc)
       end
 
-      expect(klass.transproc).to be_nil
+      expect(klass.new.transproc).to be_nil
     end
 
     context 'with custom container' do
@@ -239,12 +180,12 @@ describe Transproc::Transformer do
         expect(transproc.call(attr: 2)).to eq(attr: 3)
       end
 
-      it 'does not inherit transproc from superclass' do
+      it 'inherits transproc from superclass' do
         transproc = klass.define do
           map_value :attr, ->(v) { v * 2 }
         end
 
-        expect(transproc.call(attr: 2)).to eq(attr: 4)
+        expect(transproc.call(attr: 2)).to eq(attr: 6)
       end
     end
   end


### PR DESCRIPTION
This adds `Transformer.define!` (because `define` is unfortunately already taken), that exposes an AST-based DSL that captures all method calls as AST nodes and compiles the AST into a transproc function, which is then used by the instances of a given transformer. One **big benefit** of this approach is that we can now use both transformation functions from the configured registry **as well as instance methods defined on your transformer class**.

Here's a simple example:

``` ruby
module Registry
  extend Transproc::Registry

  import Transproc::ArrayTransformations
end

class MyTransformer < Transproc::Transformer[Registry]
  define! do
    map_array(&:my_method)
  end

  def my_method(value)
    "mapping #{value} with my instance method OMG"
  end
end

mt = MyTransformer.new

mt.(["foo", "bar"])
=> ["mapping foo with my instance method OMG", "mapping bar with my instance method OMG"]
```